### PR TITLE
cambiar 04-DiffAutomatica de .jl a .ipynb

### DIFF
--- a/notas/04-DifAutomatica.ipynb
+++ b/notas/04-DifAutomatica.ipynb
@@ -1,0 +1,995 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Diferenciación automática"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Motivación: el método de Newton\n",
+    "\n",
+    "Un problema usual en la física y en las matemáticas aplicadas\n",
+    "es encontrar los ceros de una función. Una situación\n",
+    "concreta donde esto ocurre es cuando buscamos los máximos o mínimos de una\n",
+    "función `f(x)`, en cuyo caso buscamos los ceros de $f'(x)$.\n",
+    "Aplicaciones de esto se encuentran en redes neuronales, en\n",
+    "las que uno *entrena* la red buscando el mínimo de una función de costo.\n",
+    "Otra situación de interés está relacionada con seguir los puntos de equilibrio,\n",
+    "soluciones estacionarias u órbitas periódicas, al variar un parámetro."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Un método común para obtener los ceros de una función es el\n",
+    "[método de Newton](https://en.wikipedia.org/wiki/Newton%27s_method),\n",
+    "que requiere evaluar sucesivamente tanto la función $f(x)$ como su derivada\n",
+    "$f^\\prime(x)$. Si bien uno puede en general escribir la función $f^\\prime(x)$ en el\n",
+    "programa, esto puede ser complicado, por ejemplo si se cambia la función $f(x)$,\n",
+    "y da la posibilidad de cometer errores; esta situación se encuentra\n",
+    "a menudo en redes neuronales, donde uno quiere introducir o cambiar\n",
+    "ciertas funciones durante el entrenamiento de la red. Es por esto que\n",
+    "uno quisiera tener formas de evaluar la derivada directamente\n",
+    "a partir de la propia función $f(x)$."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "En este apartado estudiaremos algunos algoritmos para obtener *aproximaciones*\n",
+    "de las derivadas de una función $f(x)$ numéricamente."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Derivadas numéricas\n",
+    "\n",
+    "### Derivada *derecha*\n",
+    "\n",
+    "Como bien sabemos del curso de cálculo, la derivada se define como:\n",
+    "\n",
+    "$$\n",
+    "f^\\prime(x_0) = \\frac{{\\rm d}f}{{\\rm d}x}(x_0) \\equiv \\lim_{h\\to 0}\n",
+    "\\frac{f(x_0+h)-f(x_0)}{h}.\n",
+    "$$\n",
+    "\n",
+    "Numéricamente, es difícil implementar el concepto de *límite*, por\n",
+    "la manera en que la computadora *simula* a los números reales.\n",
+    "Olvidándo esto por el momento,\n",
+    "el lado derecho de la definición es relativamente sencillo de implementar\n",
+    "numéricamente. Esencialmente requerimos evaluar $f(x)$ en $x_0$ y en $x_0+h$,\n",
+    "donde $h$ es un número (de punto flotante) pequeño. La sutileza está entonces\n",
+    "en cómo implementar el límite $h\\to 0$. Esto, por su parte, lo haremos de manera\n",
+    "ingenua (numéricamente) considerando valores de $h$ cada vez más pequeños,\n",
+    "por lo que esperamos obtener valores cada vez más precisos de la derivada."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Para ilustrar lo anterior, empezaremos definiendo la función `derivada_derecha`,\n",
+    "que aproximará *numéricamente* la derivada de la función $f(x)$, de una variable\n",
+    "(a priori arbitaria), en un punto $x_0$. Para esto, utilizaremos la aproximación de\n",
+    "la derivada que se basa en la definición, y eventualmente simularemos el *límite*\n",
+    "$h\\to 0$.\n",
+    "Esta función entonces dependerá de `f`, la función que queremos derivar, `x0` el punto\n",
+    "donde queremos derivar a la función, y `h`, que es el incremento *finito*\n",
+    "respecto a $x_0$ que aparece en la definición arriba. Es decir,\n",
+    "calcularemos la derivada usando la aproximación\n",
+    "$$\n",
+    "f'(x_0) \\approx \\frac{\\Delta f_+}{\\Delta x} \\equiv \\frac{f(x_0+h)-f(x_0)}{h},\n",
+    "$$\n",
+    "Este método se conoce por el nombre de *diferencias finitas*."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Main.var\"##234\".derivada_derecha"
+     },
+     "metadata": {},
+     "execution_count": 1
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "\"\"\"\n",
+    "    derivada_derecha(f, x0, h)\n",
+    "\n",
+    "Evalúa la derivada de ```f``` en ```x0``` usando diferencias finitas con el\n",
+    "incremento por la derecha.\n",
+    "\"\"\"\n",
+    "derivada_derecha(f, x0, h) = (f(x0 + h) - f(x0)) / h"
+   ],
+   "metadata": {},
+   "execution_count": 1
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "A fin de *simular* el $\\lim_{h\\to 0}$, consideraremos distintos valores de $h$\n",
+    "cada vez más próximos a cero. Para cada valor de $h$ calcularemos el error\n",
+    "absoluto del cálculo numérico, es decir, la diferencia del valor calculado\n",
+    "respecto al valor *exacto* de la derivada, usando $f(x) = 3x^3-2$ en $x_0=1$."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "f′ (generic function with 1 method)"
+     },
+     "metadata": {},
+     "execution_count": 2
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "f(x) = 3x^3-2\n",
+    "\n",
+    "#Valor exacto de la derivada\n",
+    "f′(x) = 9x^2"
+   ],
+   "metadata": {},
+   "execution_count": 2
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "errorabs_dd (generic function with 1 method)"
+     },
+     "metadata": {},
+     "execution_count": 3
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "errorabs_dd(f, f′, x0, h) = abs(f′(x0) - derivada_derecha(f, x0, h))"
+   ],
+   "metadata": {},
+   "execution_count": 3
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "9.0"
+     },
+     "metadata": {},
+     "execution_count": 4
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "f′(1.0)"
+   ],
+   "metadata": {},
+   "execution_count": 4
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "9.930000000000012"
+     },
+     "metadata": {},
+     "execution_count": 5
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "derivada_derecha(f, 1.0, 0.1)"
+   ],
+   "metadata": {},
+   "execution_count": 5
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "0.9300000000000122"
+     },
+     "metadata": {},
+     "execution_count": 6
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "#Error absoluto de la derivada derecha\n",
+    "errorabs_dd(f, f′, 1.0, 0.1)"
+   ],
+   "metadata": {},
+   "execution_count": 6
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "15-element Vector{Float64}:\n 0.9300000000000122\n 0.0902999999999956\n 0.00900299999829457\n 0.0009000299939856404\n 9.000033286099551e-5\n 8.999393571684777e-6\n 9.045354545378359e-7\n 3.4120603231713176e-8\n 7.446633389918134e-7\n 7.446633389918134e-7\n 7.446633389918134e-7\n 0.0008001052410691045\n 0.007193500536232023\n 0.029397961028735153\n 0.7699626167013776"
+     },
+     "metadata": {},
+     "execution_count": 7
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "#Errores de la derivada derecha al similar el límite h->0\n",
+    "errs_dd = [ errorabs_dd(f, f′, 1.0, 1/10^i) for i=1:15 ]"
+   ],
+   "metadata": {},
+   "execution_count": 7
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "(3.4120603231713176e-8, 8)"
+     },
+     "metadata": {},
+     "execution_count": 8
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "findmin(errs_dd)"
+   ],
+   "metadata": {},
+   "execution_count": 8
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "9.000000034120603"
+     },
+     "metadata": {},
+     "execution_count": 9
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "derivada_derecha(f, 1.0, 1.0e-8)"
+   ],
+   "metadata": {},
+   "execution_count": 9
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "El resultado anterior muestra que el mínimo del error absoluto lo encontramos\n",
+    "usando `h=1.0e-8` (con el muestreo que usamos), y el error absoluto es del orden de\n",
+    "`3.4e-8`. Esto indica que, en algún sentido, la noción de límite no la logramos\n",
+    "*simular* correctamente."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Derivada *simétrica*\n",
+    "\n",
+    "Una definición alternativa a la dada anteriormente para la derivada, consiste\n",
+    "en *simetrizar* la ocurrencia de $h$ en la definición. Podemos entonces definir\n",
+    "a la derivada usando la definición\n",
+    "$$\n",
+    "f^\\prime(x_0) \\equiv \\lim_{h\\to 0} \\frac{f(x_0+h)-f(x_0-h)}{2h}.\n",
+    "$$\n",
+    "Repetiremos el ejercicio anterior, usando ahora la aproximación de la derivada simétrica\n",
+    "$$\n",
+    "f'(x_0) \\approx \\frac{\\Delta f_\\textrm{sym}}{\\Delta x} \\equiv \\frac{f(x_0+h)-f(x_0-h)}{2h}.\n",
+    "$$"
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Main.var\"##234\".derivada_simétrica"
+     },
+     "metadata": {},
+     "execution_count": 10
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "\"\"\"\n",
+    "    derivada_simétrica(f, x0,h)\n",
+    "\n",
+    "Evalúa la derivada de ```f``` en ```x0``` usando diferencias finitas con el\n",
+    "incremento simétrico.\n",
+    "\"\"\"\n",
+    "derivada_simétrica(f, x0, h) = (f(x0 + h) - f(x0 - h)) / (2h)"
+   ],
+   "metadata": {},
+   "execution_count": 10
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "errorabs_ds (generic function with 1 method)"
+     },
+     "metadata": {},
+     "execution_count": 11
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "#Error absoluto de la derivada simétrica\n",
+    "errorabs_ds(f, f′, x0, h) = abs(f′(x0) - derivada_simétrica(f, x0, h))"
+   ],
+   "metadata": {},
+   "execution_count": 11
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "15-element Vector{Float64}:\n 0.03000000000000469\n 0.0003000000000046299\n 2.9999992570139966e-6\n 2.9995014472206094e-8\n 3.0320990163090755e-10\n 7.426592674164567e-11\n 8.139124929584796e-10\n 1.0288317753293086e-8\n 3.0057412914175075e-7\n 7.446633389918134e-7\n 7.446633389918134e-7\n 0.0003560160312190419\n 0.0027526084377313964\n 0.029397961028735153\n 0.32587340685131494"
+     },
+     "metadata": {},
+     "execution_count": 12
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "#Errores de la derivada simétrica simulando h->0\n",
+    "errs_ds = [errorabs_ds(f, f′, 1.0, 1/10^i) for i=1:15]"
+   ],
+   "metadata": {},
+   "execution_count": 12
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "(7.426592674164567e-11, 6)"
+     },
+     "metadata": {},
+     "execution_count": 13
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "findmin(errs_ds)"
+   ],
+   "metadata": {},
+   "execution_count": 13
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "8.999999999925734"
+     },
+     "metadata": {},
+     "execution_count": 14
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "derivada_simétrica(f, 1.0, 1.0e-6)"
+   ],
+   "metadata": {},
+   "execution_count": 14
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Al igual que en el caso de la derivada derecha, la derivada simétrica no simula\n",
+    "correctamente el límite, como podríamos haberlo inicialmente pensado, sin embargo,\n",
+    "la aproximación es mejor, en el sentido de que el error absoluto es menor\n",
+    "(en 3 órdenes de magnitud) que el de la derivada derecha."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Los resultados anteriores sobre la convergencia se pueden entender analíticamente\n",
+    "de la siguiente manera: si usamos el desarrollo en series de Taylor de\n",
+    "$f(x_0+h)$ y $f(x_0-h)$ tenemos:\n",
+    "\n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "f(x_0+h) & = f(x_0) + h f^\\prime(x_0) + \\frac{h^2}{2}f^{\\prime\\prime}(x_0) + \\mathcal{O}(h^3),\\\\\n",
+    "f(x_0-h) & = f(x_0) - h f^\\prime(x_0) + \\frac{h^2}{2}f^{\\prime\\prime}(x_0) + \\mathcal{O}(h^3),\\\\\n",
+    "\\end{align*}\n",
+    "$$\n",
+    "de donde obtenemos, para cada aproximación de la derivada,\n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "\\frac{\\Delta f_+}{\\Delta x} & = f^\\prime(x_0) + \\mathcal{O}(h),\\\\\n",
+    "\\frac{\\Delta f_\\textrm{sym}}{\\Delta x} & = f^\\prime(x_0) + \\mathcal{O}(h^2).\\\\\n",
+    "\\end{align*}\n",
+    "$$"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Los resultados anteriores muestran que la aproximación de la derivada derecha\n",
+    "tiene un error de orden $h$ para la derivada, mientras que la aproximación\n",
+    "de la derivada simétrica tiene un error que es proporcional a $h^2$. Esto\n",
+    "explica que, en general, la aproximación de la derivada simétrica será mejor."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "El hecho de que el *límite* no pueda ser simulado como uno quisiera no está relacionado\n",
+    "con las propiedades de convergencia (en términos de $h$), sino está relacionado con que\n",
+    "el cálculo involucra números de punto flotante (y no números en $\\mathbb{R}$) y que las\n",
+    "diferencias de números muy cercanos (como las que definen el numerador), o\n",
+    "las divisiones con números muy pequeños, conllevan la pérdida de precisión.\n",
+    "Esto se conoce como\n",
+    "[cancelación catastrófica](https://en.wikipedia.org/wiki/Catastrophic_cancellation)."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Resumen"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Resumiendo:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "- El error absoluto de la \"derivada derecha\" es lineal respecto a $h$. Sin embargo,\n",
+    "al implementarlo en la computadora,\n",
+    "para valores suficientemente pequeños de $h$, el valor obtenido de la derivada\n",
+    "deja de tener sentido ya que se pierde la exactitud."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "- El error absoluto de la \"derivada simétrica\" es cuadrático respecto a $h$. Al igual\n",
+    "que la derivada derecha, para $h$ suficientemente pequeña, la implementación es dominada por\n",
+    "[*errores de cancelación*](https://en.wikipedia.org/wiki/Loss_of_significance)\n",
+    "debidos a las diferencias que hay en el numerador y a la división de números muy pequeños."
+   ],
+   "metadata": {}
+  },
+  {
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "Plot{Plots.GRBackend() n=2}",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlgAAAGQCAIAAAD9V4nPAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdZ0BTZ98G8PuMDJKQMBXEheIEEVEUcICAighucdZZrbX2sdVWW7Wttk9b7VNbrda21j2os1VkiaCAOFGromJdCA6QHUISCGe8H+jrwICiJOck+f8+SXJLLsi4OOu+MZZlEQAAAGCpcK4DAAAAAFyCIgQAAGDRoAgBAABYNChCAAAAFg2KEAAAgEWDIgQAAGDRoAgBAABYNChCAAAAFg2KEAAAgEWDIgQAAGDRzLMIN2/efPXqVa5T1EbTNNcRGhPDMFxHaGRm9gSxLGtmEyia2ROEzO5NZLo/jnkWYWJi4rVr17hOUZtGo+E6QmOqrKw03de9Xmb2BFVXV+t0Oq5TNCYze4JYltVqtVynaEwajcZE//YyzyIEAAAAXhEUIQAAAIsGRQgAAMCi8agI7969O2jQIEdHx4CAgMzMzBcH6HS6999/38XFpWPHjtu2bTN+QgAAAOaHR0U4fvz4bt263blzZ+jQocOHD3/xRIzvv/8+IyPj4sWLW7Zs+eCDDy5dusRJTgAAAOaEL0V45cqVa9euffHFF3K5fP78+ZWVlcnJybXGbNy4ccmSJU2bNvXz8xs3btymTZs4iQoAAMCc8KUIs7KyOnToYGVlhRDCMKxr165ZWVnPDqisrMzOzvby8qr5smvXrjdu3OAgKAAAAPNCch3gXyUlJdbW1k++VCgURUVFzw4oLi5GCMnl8icDCgsL6/pumZmZMTExs2fPrvlSJpNlZmYSBNH4uRuioqKC2wCNS6vVVldX4zhf/pZ6c2b2BOl0OpZlzelSQjN7gmquIzSni3HVajXDMBiGcR3kOWKxWCAQ1D+GL0Voa2v77KtcqVTa29s/O8DOzg4hpFKpFAoFQqi8vNzBwaGu7+bh4bFgwYIRI0bUfCkWi2u2NTn3bNmbOoIgxGKxORUhMq8nqKYIRSIR10Eakzk9QSzLEgQhlUq5DtJoMAyTSqWGLsK/i9kpqfTF4STZeJ89fPkUc3Nzu3Xr1pO/XrOystzc3J4dYGVl5eLi8mS+mOvXr9ca8Kya58P2//GkBQEAALyJc4XskCPUF93wRmxBxJ8i7NGjR6tWrVavXs0wzNatW3U63cCBAxFCKSkpy5cvrxkzderU//3vfxqN5tatW1FRUVOnTm2Uh75UbJJzAgEAgEVJeMBGJFI7AslRro3cXHwpQoRQVFTUvn37ZDLZqlWr9u/fX7NXNy8v7+LFizUDFi9e3KRJE2dn5969ey9ZssTX1/fNH5RFaHQyvT/bfHbTAwCA+dmXzUxLpaIHkMHNGn/XK1+OESKEPDw8MjIyat04fvz48ePH1/xbIpFERUU17oNiCB0IIQbEUe62WCcbfh3jBQAAgBDafotZfJ5JGEx2tTPIpzSPtgi50tUO+7I7EZlMayiuowAAAHje2mvMsovM8TDCQC2IoAhrzO6Eeztgs9LNbbUzAAAwaSsvM79kMWnhRDuFAffYQRH+a31v4lIxu/kmHCwEAADusQh9eIbel82khpPNpYY9bgVF+C8pif4MIT7NoP+Gk0gBAIBTNItmpNEXi9hjQ0hHscEfDorwqfYK7Cc/IjKZVprPXBwAAGBiqmgUmUwXaNmEUFL+kjlhGgcU4XPGtsEHuGCTU2nYKgQAAONTUygikRIR6K8BpJWxLmuAIqztR1/ikZpdcxUOFgIAgFGVVqEBcVRbObYzkBAYsZ2gCGsTEehACLHyMn3yMWwWAgCAkeRrUWAs1c8Z+6U3gRv3om4oQj1ayrCN/cgJx+nCSq6jAACABbinYvvFUBPd8BU+HCwTBEWIqh/cefHGIS2w8W2x8ccoOFoIAAAGlVXGBsTSH3fBF3pyU0kWX4QsW7Lzu/L4HS/e83UPAiH0zSU4WAgAAIZyvogNiaO/64nP7MhZH1l8EWKY49zvtFfPKKM31rqHwNCu/uSGG0ziQ9gqBACAxpeax0YcoTb2Jca24bKMLL4IEcJlCse5K6vuXi3dtxaxz3VeUyu0I5CYmko9VEMXAgBAY4rJZcckU7v6k4NbcLzgARQhQgjhVjLHd7+lCh6U7llTqwsDnbH3OhOjk2kd7CIFAIBGEnWHefsEdXggGWSAZZUaCorwX5jIymHml1TJ45IdKxDz3Ozbi73wplbYkgyYkhsAABrBL1nMwnNMUhjZqwn3LYigCJ+FCUUOs75kdVXF21ew9NM1mTCEtvQjDtxj/7wHW4UAAPBGVl5mvr/CpIUTHra8aEEERVgLRgrspi1FDFO86Uu2+umUo7YitDuIePckfaccDhYCAMDrYBFaeI7ecZs5EUG0seZLCyIowhdhBGk/dQkukRX9tpSt0j65vacjttSLGJlEa2H9XgAAaCCaRe+k06l5bGo42UzCoxZEUIT64bjdhI9Ie6ei3z57tgvfd8c97bAPz8DBQgAAaAAdgyYcp28r2aQw0l7EdZoXQBHWAcdtx30ocGlT+PMiRqN6cvMvvYm0fHbbLThYCAAAr0RDoWGJVBWN4kJJa6Msq9RQUIR1wzCbke8KXd0L13/KqMtrbpMJ0N5g4uOz9LVSOFgIAAAvUaZDgxIoRzG2P5gQczCN6CuBIqwXhtmMeMfKvWfh2o/o8pKa2zxssdV+xMgkurya23AAAMBrBVrUP5byssO2BhAkj9uGx9F4Qz54ssQnpHDdQlpZXHPLhLZ4Pyds1gk4WAgAAPrlVrD9YqhBzbG1/sZeVqmhoAhfiXVwpNQ3tPCnBVRxXs0ta/2JW+Xs+utwsBAAAGr7R8n2i6Hf6cTNskoNBUX4qqyDRlsHjSn6+ROq6BFCSEygPUHEFxfp0wVwsBAAAJ66WsqGxNGfe+MfephGxZhGSp6Q9h5iPWBc4dqPq/NzEEJucmxTX2L8Mbq4iutkAADAD+cK2YHx1GpffHp7k+kXkwnKE1K/wYphM4t+WVz9KBshNLQVPrI1NiWFgq1CAAA49ogdmkhtDSBHuZpSuZhSVp6QeAfajJhduP5TXe4/CKGVPYlSHVp5GQ4WAgAs2p+5+KQU+tAAcqALv8+NeQEU4euw8uprN2F+8e/LdPeyBDjaE0T8dI1OzYPNQgCAhfrtBrP4kiBxMMGTBSUaBIrwNYk797Sd+FHR719U3brUXIrtDCQnHKcfaaALAQAWZ+VlZuVlJi5Ix58FJRoEivD1iTt2t5/+Wcn2lZU3LgQ1w2Z2xCYcpynYRQoAsBg1C0psv8WcCCfayEx1SwCK8I2I2naxn7m8NOp7beapz7sRYgJ9cRGusgcAWASaRTNP0Kl5bFoE6SI1yW3BGlCEb0rYsr3DrK/K9q2runIiqj8ZdYc9lANbhQAAM1dFo3HH6HsqNpmXC0o0CBRhIxA0d3OYs6Lsr9/El4/+0Z94J53OVpnqLgIAAHipimoUkUgJcBQfSsp4uaBEg0ARNg6BU0vHd79Vxm3vcjfxY09i7DG6CnaRAgDMUUkVGhBPucmxnYGEwCw6xCx+CH4gm7ZwfP9/qqO7Z5VEt5RhH52FJgQAmJtHGjYghgpwxtb35vtU2q8OirAxkfZOjnNXqk9E/6Lbe/Qhu/M2HCwEAJiPG2WsXzQ9tb1pTKX96qAIGxlh28TxP6uYyykxaPv8M3RWGRwsBACYgwtFbP9Y6gtvfEEXcysOc/t5+ICQ2zrOXWmdnbGf2h6ZTKsprgMBAMCbScljBydQP/cmTGgq7Vdnhj8SH+AyG8e5/+tYcmX5w19mpUETAgBMWHQOE5lMRfUnR7Y2z8owz5+KD3CJzGHON/703f7n123MghNnAAAmacdtZs4p5shgMsTUptJ+dVCEBoSLpU3f+3aAKB/t/+7vAtguBACYmJ+uMZ9fYI6FEd3szbYFERShoWFCcct3l/vKVFc3fFdeCduFAADTwCK07CL9axaTFk60V5hzCyIoQiPAhCL3uctaCrQZG1bfKa3mOg4AALwEzaJ30un4++yJCLIFzyYRZTSqvC8nI6YxtyugCI0BEwj95n9hL8YvrF726UmNUsd1IAAAqIOOQeOO0dl8nURUdXS3uJMPwhvzQkYoQiMRCkivt+f1a+cw7Phn3XYr11xlYMEmAADfqCk0NJGqZtDhgXycRJQuKVCfOyofNKlxvy0UoRHhuNPEDzq6t0/JX3r6XpnHAWpfNpQhAIAvSqvQwHiqqRW2P5gQ83LqGGX8NlnfoYTctnG/LRShcWGYzYh3bLr0XJ35ya+eZV9eZAbEU1dKYPYZAADH8jQoMJbq4YBtDSBIXjZD9aPsqhsXZYEjG/078/LHNXfywW9Je4Z03Pvx+X5FY1zxQfHU5BT6sZbrWAAAS5WtYvvFUBPd8DV+BL/OjXmG8vAm64HjcbGk0b8zFCE3rIMjZf1Hlf6yaLp9XtYYQTMpct9fvewiDVdYAACM7GopGxBDL/TEF3rytxGqbmdSBQ+k/mGG+Ob8/bHNnqxPuDxsSuG6hdKi7BU+xJlh5PVS1GEftf0WA7tKAQDGcSKfDYqlVvniMzvyuA5YVhmzSRE+HSNIQ3x7Hv/kFkDSI0gxfFbh+k91OTfc5NjeYGJPEPFLFuN7iDr1GNoQAGBYsffZUUnUzv7kGFded4Hm71REM1ZefQ30/Xn9w1sCSbcAuwnzizZ8XnXrEkLItwl2aij5kSc+MYWOTKbvqaAOAQAGEXWHmZFGHRpIDuT3JKIsTZXHbVdETEeYoXJCEXJP3Lmn/bTPSravrLxxASGEITTGFb82iuzugPWKpj7JoMthOhoAQKP6+Tqz8BxzdDDp14TXLYgQUp+MJR1dRO29DPcQUIS8IHLrYj9zeWnU99orJ2tukZBoUVf84nCytAq576c23GBo2DgEADSGlZeZHzKZ1CFEFzu+tyBbpVUl7VEMmWrQR4Ei5Athy/YOs/5btn+d5tzRJze6SLHf+hAHBxC7bjM9D1EpeVCGAIDXxyI0/wy9N5s5PZRsK+d7CyKEVMf2iTp4C5q3NeijQBHyiKB5W8f3vlPGba9IO/Ts7d0dsNRwcpk3/vYJekA8db0M6hAA0GAUg6an0ReL2WNhZBMrrtO8AqairCI9Rh460dAPBEXIL2TTFo7/+b4i7ZDq+IFad0W0xLNGk+Et8IAY6p10uqiSk4AAAJOkodCwo1RxJYofRCqEXKd5Ncr4HdKeA0h7Z0M/EBQh75B2TR3/873mbKLy8OZadwlwNM8DvzFGICaQ+4HqlZcZHUxWCgB4mTIdGpRA2YmwAyGElUGuxGt8VOFD7aUT1iFjjfBYUIR8RMjtHOeurLxxoezAesTW3hFqL0Jr/IhjYeTxPKbrn1RMLuwpBQDUKV+LAmIoHwdseyAhMJ2PfGXMFuug0bhUboTHMp3fioXBZTaOc1fq7t8q3bf2xS5ECLnbYgmh5I++xKJzNMzcDQDQ666K7XOYimyD/+DL30lEX6TL/Ud3L0vWd5hxHg6KkL9wK5njnG+porySHSvrWo45tDmWOYp8yw0PTaAmp9D5MHM3AOD/XS9jA2PouZ3xJV4m9lGvPLxFHjYZExppXWAT++1YGkwodpj1JVtdVbTpK7Za/8L2OIYmt8NvjhG0kSOP/dXLLtJaysgxAQC8c66QDYmj/tcL/8DDxD7nK6+dpcuLpT4hRntEE/sFWSCMFNhNXYIJBEUbPmOr6tzikwnQMm/i3HDySgnqfZjK0xgzIwCAXxIesBGJ1NYAcmwbU/uQZ1ll3DaboTMQbrylgU3td2SRMIK0n/wpaedU9NtnTGV9FdfGGvszhJjSDu95iLoMRw0BsEi77zBTUqm/Qvg+iahe6nNHcZFE7O5rzAeFIjQROG477gNBi3ZFPy9i1OX1j53ngf/gi4fGU6kwEw0AFuaXLOajc8zRwaR/U9NrQbZaV56wUxEx3ciPC0VoOjDMZsQ74s49C9d+RCuL6x87xhWPCiIjj1FRd+BKQwAsxcrLzPdXmJQhhCfvJxHVqyLtkLBFO6FrZyM/LhShiZEPfkviE1L400dUcX79I/s7Y8fCyMUZzLKLsOw9AGaOReijs/TO28yJCMLNFCYRfRGjrVAd3y8fMsX4Dw1FaHqsgyNl/UcV/byIKnxY/0h3W+zUUCI6h515gqZgyxAAM0Wz6O00+lwhmx5BNpOYZAsihFRHd1t59hY0bWn8h4YiNEmyPuHysCmF6xZWP8quf2QzCZYWTj5Qs6OTaQ1cVgGA2amiUWQyXVDJHgk1mUlEX0Qri9VnE+UDJ3Dy6Dyade78+fOJiYkFBQXt2rWbOnWqVCqtNeDKlSvx8fFPvpwyZYqTk5NxM/KIpEcQIojC9Z86zFwmbNWxnpEyATo0kJyRRgfFUdEDTGPWeQDAq1DqUEQi1VKG7e5HmtD0aS9Sxm6V9QknbBw4eXS+/OYqKipGjBhRVlbm5uZ28OBBPz8/rbb2NXPnz5/ftGlT6f+jKEvfwJF0C7CbML9ow+dVty7VP1KIo+2BRGhzzP8wdVMJp5ICYA4ea1H/WMrTDtseYEqTiL6oOu9eVdZ5Wf/RXAXgyxahRCK5e/euQCBACM2aNatZs2anT58OCgqqNczd3X3FihVcBOQpceee9tOWlmz71nbiR+KO3esZiSG0zJtoKWP6xVAHQsjeJnhqNQDgiXsqdlACPaI1tsLHeBeeG4jy8CbrAeNwsYSrAHz5KwLH8ZoWRAgxDFNZWSmX65l0PDc39+uvv/79998LCgqMG5C/RG6e9jOXl0Z9r71y8qWDp7fHtweSo5Oow7lw8gwApup6Gdsvhn63E24GLVh1J5N6fF/qH8ZhBozVt7KBgbAsyzC1P38xDMPx5/r4/fffv3HjRmJiIoY9t9Xy119/xcTEtGjR4tKlS2lpaampqV26dNH7QP7+/iKRqE2bNjVfikSilStXEgTHr5iKigqZTGagb04/ylZt+0oy6C2hd/+XDr5QjI1NIxe607Pav34dajQasVhc67kzaQZ9goxPp9OxLCsSGWnaYiMwsyeIZVmNRvPiyRAvdaEYi0wjVnSjx7Tm12GOiooKqVRa63P7JVi2/LfFIr8wUde+BkolFApJ8iX7Po26a3TatGl//PFHrRv9/PxSUlKefLl69eojR46kpaW9+NscMWLEiBEjav49e/bsL7/8ct++fXofSC6Xt2jRonv37k++lEg42+h+QqfTGfBTybWj8N0VJRs+wymdtO/Q+sf6N0NpQ9iIJPKuBq3qieGvtZeUpmmRSGRORWjYJ8joMAwzsyI0syeIZdmaN1GD/tfxPDQpjdnUBw9tzrttwerqapFI1KAirLx0AlE6uU8walB9NsSrfEYZtQi3bt26devWegasXbt23bp1KSkpLz0d1M/Pb926dXXda2NjExISMnasMZY2fnUEQRh0q5Ro1tpx7ndFv3yK0dXWwZH1D3azQScj0PCj1IRUtCOQEDc8V82PY05FaOgnyMgIgmBZ1sx+InP6cWqenQb9RAdzmHfTad4e46/5cV69CFmaUiXssB0zl3jZFpuh8ehTbNOmTatWrTp69Gjz5s2f3KhWqxMTE2tOENVo/p1vmmGY6OjouvaLWjLSwdnxP6u0l9JLdn5X17JNT9iJ0NHBJIGhsASq7CVjAQAc+zWLee8kkzCYpy34GtSnE0h7J1H7blwH4U0RFhQUzJw5k2XZMWPG9OjRo0ePHtHR0QihnJycQYMGqdVqhNCwYcP69+8/YcIEDw+PrKysr776iuvUfEQo7B3/8z3C8II1H9KlLzmlSESgP4IIH0esz2Eqt4JfxxsAAE+svMx8d4VJDSe6muYkoi9iq7SqxChF+DSugyDEn8snbG1tMzIynr2lVatWCKE2bdpcuHDB2toaIbRv377z58+XlpbOnTu3Z8+eLz3+abEwgdBu4kcVqQcL1sy3n7a0/svtMYRW9iSaSRj/w/ThgUQ3ezN5mwFgHliEFp6l4x+wJ8IJF6n5vD1Vxw+I2nsJmrtxHQQh/hShQCB4cm7Ls8Risbe3d82/a478GTeXCZMFDCebuBRvXK6ImC7pOaD+wfM88BYyNCie2h5IhjY3nzcbACaNZtGsE/S1MjY1nLQ3n/OEEFOhrDgR3eTDNVwH+Rdfdo0CQxB38nH8z/flSXvK/vwFvXDhSi0jW+OHBpLTUqnfb8AlhgBwr2YS0cda9liYWbUgQqg8YYfEJ4R0cOY6yL+gCM0c6ejS5IMfq/Nzi37/nNFW1D/Yrwl2IoL8Xyas3AQAxyqqUXgiJSbQXwNICV/23DUOqjhP83eaPOQlZ7YbExSh+cMl1o6zvxY0a1Pwwzzq8f36B7vJsbRwMiaXnZFGV8OWIQBcKNCifjFUBwW2I9C0JxHVS3l4s3X/UbjMhusgT5nd7xjoheOKiOnWwWMK1y2s/Odi/WOdrFBqOPlYy4YfoVTVxskHAPhXTgXbN4Ya2Bxb50+83mQXfKbLvanLvi7rN5zrIM+BIrQgUt9Q++lLS6NWqZL3vmQkiQ4NJF2tseA46nHtVUAAAIaSVcb2i6Fnm8UkonopYzbLB7+FCfl1zBOK0LIIXd2bfLhGe+lEyY6XXHFPYOjXPsSo1rhfNHWjDC4xBMDgMgrZoFhquTf+oYd5fjJXXs+gy4qkLzuJ3fjM89cN6kHYODi+/z+W0hWu/4QuL61/8KKu+BfeeGAsdSIfuhAAAzqex0YkUpv6kVPbm+nHMssq47YqImYgnHcbu2b6Gwf1woRi+6lLrDx8C374j+7+zfoHT2mH7wwkRydTe+7CyTMAGMTBHGbCMWp/MBnWwuyOCv4/TUYSRgqsPHy5DqIHFKGlwjDr4EjbMXOLfvtcc/5Y/WNDXLCkweTCc8x3V6ALAWhk224xc08x8aFkHyezbUG2WqdM2GEzbKbhVpl4E1CEFk3s3stxzrfl8duVhzejelem7GKHnYogom4z807TDOwlBaCRrLzMLL/IHA8jvMx6dsOKE9FCFzehqzvXQfSDIrR0gmauTeb/pMv9p+j3L5hKTT0jXaTY8SHk5RJ2TDKtpYwWEADzxCK09BKx/RZzIpxopzDnFmS0Fapj++VDpnIdpE5QhADhUrnju9+QDs6Fa+ZTxfn1jLQVoSOhpABHgxKoUp05v3UBMCiKQTNOMGcKsfQI0pym0tZLlbTHqoufwKkl10HqBEUIEEII4YTNyHdlfYcWrvmw6talegaKCBTVn+jliAUnEnn1bUACAPSrpNHoZPqxlo3uT9ny64K6xkcri9VnjsgHTeQ6SH2gCMFTUv8wu6lLSnZ8V/8V9ziG/teLCHRi116Hc2cAaJjyajQ4gZKQ6GAIYWaTiOpVHrdN5j+EsHHgOkh9oAjBc0RtPBznrdKcP1a69yeWru9I4Mx2zB93EZw4A8CrK6lCA+OpTjbYTnOcRPRF1Y9zK7MyZMGjuQ7yEhbwVIAGIu2dm3zwI6MqK/p5EVNRVtewTgpWIUTpj6EJAXgluRWsfzQV6Iyt722Gk4jqpYzeZB0ciYulXAd5CShCoAcmsrKf/pnYvdfjVf+pfnC7rmET2mC7bsPeUQBe7kYZ2zeGntXRbCcRfVHV3atU3j1p73Cug7wcFCGoA4ZZB0faDH278Nel2isn9Q6Z2BYdyGaqYO1CAOp1vojtH0st88bnd7Ggj1zl4c3yIVMwUsB1kJezoGcFvAarbv0c3/1aeXCD3ivuXaSYhx0W/wA2CgGo0/E8NiyBWt+bmGauk4jqo72czuoqJd79uQ7ySizoiQGvR+DStsn8n3T3soq3fcPqKmvdO7Etvus2HCYEQL9DOcyEY9SBEHJEa0v6sGVoZdx2xdC3+Tmh2oss6bkBrwuXKRze/QYXSQrWzKdKHj97V2QbPOkhU1bfgk4AWKjtt5j3TjHxoWRf851EVK+K0/GEtY24gzfXQV4VFCF4JRgpsB3/oax3eOHqD6puX3lyu0KIgprhf96DvaMAPGfNVWaZBUwi+iJWV6lK/EMxbCbXQRoAihA0gNQ/zHbCRyXbvlWfOfLkxolucO4oAE+xCC06R2+4waSZ+ySieqmOHxC5eQpbtOM6SANAEYKGEXfs7jhvVUXKAfXBX2uuuA9viV8pYR+o4UghAIhm0Tvp9PE8NjWcbG7uk4i+iKlQVqQdkg+ezHWQhoEiBA1GOjRznPcDU/BAcyoOISTE0fBW+B93oAiBpdMxaNwx+k45mxxGOoi5TsMF1dE/JN37kw7OXAdpGP1T3eXk5Bw/fvzSpUtFRUUkSTZt2rRXr14BAQH29vZGzgf4CbeSiQeMV0dvsO43DGHYRDf8g9P0x57wdxWwXGoKjTxKSQVY3CBSZCkXzT+HKS3QXDje9JPfuA7SYM8VIcuyf/7557p161JTU1mWFYlEdnZ2FEWVlJTQNC0UCocPH/7hhx/6+vpyFRfwh8DVvRLDq+5eFbXtEuCMKatRZgnbxc7i9gUBgBAqqUJDjlBe9tjP/pYyfdqLKhN3SQOGE9a2XAdpsKd/wt+6dcvf33/SpEn29vY7d+7Mzs6urKx89OhRQUFBVVXVlStXVq9e/fjx4969e48dO1alUnEYGvCExDdUfSoOIYQhFOmKRd2BU2aAJXqkYQNiqABn7BeLmUT0RdUP71A5WdYBI7gO8jqeFmFmZma/fv3u37+/f//+CRMmtG7d+sldBEF06dLl3XffTUlJuX79OkmSjx8/1vPNgIWx8gmuzMqomZh7cjs86g4Li1EAS3OjjPWLpqe0t6BJRPUqO7RR3H8MJjTJQ6NPd42OHDly5MiRL/0PHTp02LVrlyEjAZOBW8msPPzU55Ksg0a722I1i1H0s7Brh4Elu1DEhh+hvvYhplvS9Gkvqsw6T5cWWHUP4jrIa9Lz5JWWlg4YMODEiRPGTwNMjtR/iPpUbM00pBPb4nBBIbAcKXns4ATq596W3oKIZZWxWxURMxBuqtvEep4/mqaTkpIEAhOYMhxwTti6IyaWVN26jBCa5IbBYhTAQkTnMJHJVFR/chwzIDoAACAASURBVKRFTSKqj+b8MYwgrbr4cR3k9el5Ch0cHDp16pSRkWH8NMAUSX0HV5yKRbAYBbAYO24zc04xRwaTIS6WfiCApanyhJ2KiOmmMr+2Xvr/ltm4ceMPP/ywdevWkpISIwcCJkfqE1x1829aWYxgMQpgAX66xnxxgTkWRnSzsElE9ao4ES1wbiVy8+Q6yBvRX4QjR468d+/etGnT7O3tsecZOR/gP0xkZdW1ryYjCcFiFMCssQgtu0j/msWkhRPtLW8S0RcxlWpV0l55+DSug7wp/TPLzJ07t6KiwshRgOmS9Qkv2rjcOmiMQojXLEZh6acPALNDs+jdk/SlYjYt3EKnT3uRKmmvlUcvgVMrroO8Kf1FuHTpUiPnACZN4NKWkNlU/nNR3KnHRDfs5+tQhMCs6Bg06ThdVMkmh5HWcB4hQgghWlmsPh3f9OOfuQ7SCF7yacUwTH5+PkVRxkkDTJe0d1jNLDOwGAUwM2oKRRyhqhkUFwot+FR5/Hap32DCxpHrII2gziKMjo728fGxsrJydnaWSCSenp7bt283ZjJgWiTegVV3MmllMSxGAcxJaRUaEEc1k2L7ggmxqV4m1/iox/e1V89YB43mOkjj0F+Eu3fvHj58eFFR0Xvvvffdd999+OGHNE1PmTLlxx9/NHI+YCowoVjiHaA+HY8QmugGV9YDc5CnQQGxVD9nbHM/goSd/c9QHt5kHTIWl1hzHaRx6H9uP/nkk/Dw8Js3b/7www8ff/zxypUrMzMzZ82a9cUXX1RWVho5IjAVUv8h6jMJiGGeLEbBdSIAXt9dFds3hnrLDV/hQ8AZos/S3btR/Shb1ieC6yCNRk8RFhQU5OTkLFmy5NnJZXAc/+yzz1Qq1Y0bN4wYD5gSQTNXwsZRe/0cLEYBTN3FIrbPYerTrjissvmiskO/ywdPxkjzOV6q5znGcRwhVF1dXev2mlNmau4FQC+Zf5j6VCyCxSiAKUvNY0MTqLV+xIwO8HFXm/bKKbZKI+lhqvNr66V/irX27dt/8cUXGo3myY3V1dVLly61s7Pr1KmTEeMBE2PVLUCX8w9V8tjdFrMRovTH0ITAxBzKYSKPUXuDyVGu0IIvYJjyuK2KiBkmPaHai/RfR7hq1arhw4e3bt16yJAhzs7OhYWFiYmJubm5GzduhMm4QT0wgVDSI0hzJkEeNmVCW3zXbaafE5xpB0zGztvMR2fp6AFkryZm9UHfWNRnEnCZQtypB9dBGpn+P3nCw8OPHz/u7e29d+/eb7/9dseOHa6urrGxsTNmzDByPmByZP5D1GeOsDQFi1EA07L2GvPZBSY1HFpQP7ZaV574hyLcDFtAzxZhZWXl9u3bAwICEhISEEJardbKysrowYCpIpu2IB1dKq+ecenap4sdFv+AGd4KdjEBvlt5mdl2i0kLJ1pIoQX1Ux0/IGrTWdi6I9dBGp/+hXnfeeed0tLSmi+hBUFDSf3/nWVmohssRgH4jmbR7HR6fzaTGk5CC9aFUZdXpP4lD5vCdRCD0FOEjo6Otra2eXl5xk8DzIOVV9/qR9lU4cMxrrAYBeA1HYMmHKdvKtnkIaQjTKVdt/LEKEn3/qRDM66DGISeIiRJcunSpcuWLYMuBK8HI0iJT7D6TIJCiIKa4Qey4YJCwEdqCg1LpKpoFBdKyuEswLpRJY81549ZDxjHdRBD0X/WaFZWVl5eXtu2bbt37+7s7PzsXXv37jVKMGDapP5DClZ/KB88eaIbse4aA9djAb4prULhiZSbHNvUF6ZPe4nymC2yfsMJa1uugxiK/iLMyclp2bIlQkir1d69e9e4kYA5IB2cBc1aa6+cDPcKfCedfqBmm8PRF8AbeRoUmkAFOmOr/WD6tJeofni36vZl27HzuA5iQPqLMDEx0cg5gPmR+Q+pSD/s6B1YsxjFx57wgQN44a6KHRRPz+yIL4Tp016BMnqjfNAkTGTOZ03qeR3k5eVhGBYTE2P8NMCcWHn6U4UPq/NzYTEKwB9XS9nAGHpRV2jBV1J54wJV8ljiO4jrIIal56VgbW2N47hcLjd+GmBWcELiE6I+kwCLUQCeSMtng+OoH3zxt+Gg9atg2fLYrYrwaRihf9+h2dDzapDJZKGhoQcOHDB+GmBmZL2HaDKSkK4KFqMAnIvJZUcnUTsDydEwieir0Vw8jjDcyrM310EMTn/PT506dc6cOYWFhREREY6Ojs/eFRISYpRgwBwQtk2ELdtrL6dPbhcUdoT+ugfC4UAh4MK/k4gOJH1h+rRXw9JUefwO27HzzGx+bb30F+H7779fVFT0xx9//PHHH7XuYlnYwQUaQOofpjp2wN0nWCFE6Y/Zfk7m/6YCfLPuOrPiMpMURnrYwsvvVanTD5NNW4raeXEdxBjqPGv0xfUIAXgNVu69yg6sr867N7FtS1iMAhjfysvM1lvMqQiipQxa8FWxVVpV8l6Hd77mOoiR6C9CT09PI+cAZgsnpL6h6lNxk0Lf7fon/ZMfIYIqBEbBIjT/DH0in00Lh+nTGqY8aY+4k4/ApQ3XQYykvoPGN27cOHDgwK5du2q+LC8vf3apXgBekdQ3VHMxpZmgqmYxCq7jAIugY9D4Y/SlYvYYTCLaQHR5ifpUnDx0EtdBjEd/EapUqoiIiE6dOo0ePXrRokU1Ny5YsGDYsGFGzAbMBGHjIGzdWfN3KixGAYyjZhJRLY3iYRLRhiuP3yH1HUTYNuE6iPHoL8I5c+acO3duz549+/fvf3LjpEmTUlNT1Wq1sbIB8yHrHaY+GQeLUQAjKK1CA+OpJlbYgWBCDPvhG4gqeKDNPGUdHMl1EKPSU4SVlZV79+5dvXp1ZGSkg4PDk9s7depUXV19//59I8YDZkLcyYepKJMU3IbFKIBB5WtRYCzVwwHbGgBTab8O5eHN1kFjcIk110GMSs8rpbi4WKfTdevWrdbtAoEAIVRRUWGMXMDMYJjEN7TiVNxENwymWwMGkq1i+x6mRrTG1sBU2q9Fl3NDd/+mrO9QroMYm54itLe3FwqF169fr3X7qVOnMAxr3bq1MXIBsyP1DdVeSgtrUplZyt5Xw5FC0MiulrIBMfRCT3yZN+wPfU1lB39XhE3BBEKugxibniIUi8VDhw795JNPbt68if3/nAJXr1794IMPQkJCnt1ZCsCrI+S2onZe9KWU4a3w3XegCEFjOpHPBsdRq3zxmR1hf+hr0maeZivVkh7BXAfhgP4XzU8//YTjeOfOnadMmVJcXOzp6enl5aXVan/99Vcj5wPmROofVnEyBhajAI0rJpcdlUTtCCTHwCSir41hymO3KiJmINwSf4f6f2ZnZ+fz589/9913HTt2dHd3t7e3X7p06eXLl9u0sZTrK4EhiNt3Y3VVftU3YTEK0Fh23WZmnKAODSQHusBhwdenPpeIS+Xizj5cB+FGnYtryGSy+fPnz58/32hR7t27xzDMk0dv0kTPVSw6ne7ixYsKhaJTp05GCwYaDYZJfQdpTsaNdftP1B3mWzs4lgPeyM/XmW8vM0mDyS520IKvj63WlSfssp+6mOsgnOHRKlNeXl4KhYIkSYTQ0KFDf/zxx1oDcnJygoKCmjZt+vjxYy8vr7179xIEfJKaGKlvaP5/p08JfDs01QoWowBvAiYRbSwVKX8KXTsJW1vu1sXTXaMHDx5csmRJSUlJ/f/h1q1bkydPvnPnjiHSpKSk3Llz586dOy+2IELoq6++CgkJOXXqVGZm5tWrV6Ojow2RARgULpWLO3VvcetYzWIUXMcBJolF6MMz9L5sJnUICS34hhhNhSr1oCJsCtdBuPS0CDt37nz06NHmzZuPHz9+3759Dx48eHIXwzBZWVmbNm0KCQnp2LGjRqPRu9/yzRUVFd2/f7+ulZ727ds3bdo0hJBEIhk7duy+ffsMkQEYmtR/SMXJ2Ilt4IJC8Dp0DJpwnP67mD02hGxixXUa01eeGCXx6ks6unAdhEtPd422b9/+7Nmze/fuXbt2bWRkJEJIIpHY2dnRNF1ziT1JkkOHDk1LS+vd2yALFuM4Pn78eK1Wi2HY5s2bBw4c+Oy9SqWyvLzc1dW15svWrVsfP368rm+lVqszMzPt7e1rvhSLxX369DFEZvAaRG6eGIYmibK6ZnaAxShAg2goNDqZIjEsfhBpxaMDO6aKKnmsyUhquug3roNw7LmXEoZhY8eOHTt27O3bt1NSUq5cuVJYWEiSpJOTk4+PT2Bg4BtuCM6ePbu4uLjWjSNHjhw/fjxC6MaNGzXff/369ePGjbt3755cLn8yrGbhC6Hw3ys9xWJxPbOe5uXlZWdnnzp1quZLuVzu4eFRc/SRQ2q1GjOjtZ41Gg1FUfhrnWxNduuPnTvc2bbdX7c14S582S40sydIp9OxLGtOC4vmKbVTkoWuMrS+ZzVdiUx9jiuWZbVaLbdLnWuiNwl7hWpxAWqMKcPUajXLsnx7E4nF4pd++Ou/283Nzc3NrdEDDR8+XKvV1rqxQ4cONf940rJz5sxZvHjx1atX/f39nwxzdHTEcbykpMTW1hYhVFRU5OzsXNcDubm5jRgxYuzYsY38A7wZlmVlMhnXKRoNjuNisfj1ilDSLyL/y6lvj9XsfyAf14Evm4Rm9gTVFKFIJOI6SON4pGFHnhEObkF814vAkDn8UCzL4jgulUq5ClD9KFt1N9Nh3Ae4WNJY31MqlfKtCF+FUTeSQkNDX2VYUVGRWq22s7N79kaSJL29vU+cONG2bVuEUHp6uo+PhV7yYgZwK5nYo1do8fH/PIwo0xE2FjejE2iY2+XsoHh6iiv9eU94rTQaZfRG64ETG7EFTZeeIkxOTo6Njc3Nzc3Pz6dpumnTpi1atAgODo6IiDDc5Qrp6elxcXHe3t4ajWbNmjUhISE1W4pbtmzZtm1bSkoKQmj+/PkfffSRtbV1dnb20aNH9Z5ZCkyFzD+s5I8fQ3yGHshmZnSwxMkswCu6WsqGJdBLu+HjXSius5iPqttXqMJHUr9X2jgxe88VYUlJSWRkZHJyMkEQTk5OdnZ2BEH8/fffcXFx69at8/T0PHTokIEm3W7VqhVCaM+ePRKJ5O23354xY0bN9nWnTp1GjBhRM2b8+PEkSe7du1cul6ekpLi4WPRpTqZO6OqOEeRs8dVvbntAEYK6nClgRyZRa/yIMa64SsV1GrPBsspDvysipmMEnHGEUK0inDt37sWLF3/55ZfRo0c/O7m2SqWKjY1duHDhuHHjzpw5Y4gcLVq0+Oabb1683dfX19fX98mXY8aMGTNmjCECAOOT+od53YnPJN3vq9kWUtM7rgAMLSaXnZ5G7ewP06c1Ms3fqQjDrLrCufT/evqXuE6n279//5o1a2bPnl1riQlra+tx48bt3r377Nmzd+/eNXpIYJ4kPsG6mxcmOpXDYhTgRbtuM2/DJKIGwNJUedx2Rfh0ZIJntRjI0yLUaDTV1dX1nCxac1dpaakxcgELgIulVl16T6tIgivrQS3rrjOLMpijg0m/JvBh3cjUJ2PJJi6i9l5cB+GRp0WoUCiaN2++fv16mqb1Dl27dq1YLG7Xrp2xsgHzJ+0d1jQzQVXNwmIU4ImVl5mfrzOnIgiYSrvRsVVaVdJuxZCpXAfhl6fHCDEM++abb6ZMmXL+/PmRI0d6eHjY29sTBFFUVHTr1q3o6OiMjIzly5c/e5E7AG9I2LIDZiWdb3Up6o43LEYBaBa9d5K+UMSmhZOOYq7TmCNV8l5Rxx4Cl7ZcB+GX506WeeuttxQKxWefffbieStt2rTZsGHDzJkzjZgNWASZf1hYZkKgphssRmHhdAx6K4Uu0LLJQ0i5gOs05oipKKs4Fdd0wVqug/BO7XNnhw4dOnTo0IcPH+bk5OTn52s0GoVC0bFjR9gjCgxE0r2/KGZLG8/i9MdN+jlBE1ooNYVGJ1EiAosPJcWwa8AwlHHbpT0HELYGWTLBpOm/iMTFxQWu0gPGgYmsrLz6flSZvOv22H5O8BFoiUqrUHgi1U6ObexLkHBNqWFQhQ+1l9OdFm/kOggfNeBFp9Pp4JRRYAiy3uFd78QfvEtV6T9PC5izPA0KiKX6OmFbAqAFDUh5eLN10BhcCid56NGA193+/ftrzf8JQKMQuLQRKuwmsBfj7sN1FJblrortG0O95Yav8CFgt7jh6HL/0eX+I+s7lOsgPAV/gAFekPYOe6skYRdcWW9JLhSxfQ5Tn3bFP/aEDyLDUh7eLB88GROaw6odhvDcMcKoqKiKulelOnfunOHzAAsl6RbYNHrTtXsFZTpnWIzCEqTmsWOSqV96E6NcoQUNq/LaWUZVJvUJ4ToIfz1XhIsXL87JyeEqCrBkmFAk7d7/o7yjB7InwRzcZi86h3n7BB3VnwyB6dMMjWGUMVsUEdPQay0daiGeK0JbW1s3N7eVK1fqHZqQkLB06VKjpAKWSNp7SNBPn8y6GTmjA1xKbc6232IWn2eODCa72UMLGpw64yhuJRO7+758qAV7rgi9vb3T09O7d++ud+g///xjlEjAQgmatpQ0cbbNybiv7gOLUZirNVeZNdeYY2FEewU8xQbHVuvKE3bZT/6E6yB899zGco8ePW7fvl1eXq53qJ2dXV0dCUCjsPYPm1ORAItRmCUWoU8y6N9uMGnh0IJGUpH6l7Ble6FrZ66D8N1zRfj2228XFRVJpVK9Q0NDQ8+fP2+UVMBCWXXr17r8zrGrD7kOAhoZzaJ30uljj9i0cLI5bO4bBaOpUKX8KQ+bzHUQE/BcEQoEAltbW4J4+ewe+fn5R44cMVgqYKEwUmDbM6jfw0RYjMKcVNFo3DH6TjmbHEY6wPFfY1Ed/UPSta+gaUuug5iA1zyP6MKFC/PmzWvcKAAghKT+YaNKknbf0nEdBDSOimoUkUjRLIobRFrDVNrGQpcVqTOSrAdN4DqIaYATagG/kE2aC5u2eHT+NAPbhKavpAoNiKfc5Nj+YEIE88gakTJ2q6x3OCGHucBeCRQh4J0m/cJGFcanP4YmNG25Fax/NBXgjK3vTcACW8ZUnXev6sYFWf9RXAcxGVCEgHesuvbpWJWbcOk+10HA68sqY/vG0DM74it8YEvQ2JTRG60HjsfFEq6DmAwoQsA7GEGKfQbILiXAYhQm6nwRGxRLLfPGF3SBTxhjq7qdSRU8kPqHcR3ElMDLFPCRU8Dg4SXJCdmVXAcBDXY8jw0/Qm3qR05rDx8vRseyyphN8vBpGKF/rVmgF7xSAR+R9s7VTdteP3WS6yCgYQ7mMBOOUfuDybAWcFSQA5pLaWx1tcSrH9dBTAwUIeCp5v2HdL4ZXwaXUZiOrTeZuaeY+FCyjxO0IAdYmiqP224z7G2Ewe+/YV6zCIOCgpKSkho3CgDPsvfydaPyjlzM5joIeCUrLzNf/s0cDyO8YCptjqhPxZEOzqL23bgOYnr070f+73//q3dhQltb29atWw8YMMDOzq558+YGzgYsG06oPQdUnIpHvnO4jgLqwyK08Cwd/4A9EU64wPRpHGGrtKqjux1mfcV1EJOkvwh37Nhx7949nU6HEJLL5TXTcIvFYgzDtFqttbV1VFRUeHi4UZMCy9Nl0BDJt+89KJ3e3BYm5uKvOSfpq6VsegQJKypzSHVsv6hDN0HztlwHMUn6d42uXr26WbNm+/bt02q1SqVSpVJt2LChSZMmJ0+ezMrK8vb2njx5cj1r2QPQKKzsHQsdOpw+lsZ1EFCnzTeZE/lsQii0IJeYirKK9MPy0ElcBzFVeoqQYZjZs2d///33o0ePFovFCCGZTDZz5sy5c+fOmzevY8eOu3fvLi8vT09PN3paYHFkfcJsL8dynQLol1nCfppB7w0mpHCuPqfK43dKfUJIe2eug5gqPa/fgoKC3NzcLl261Lrd09Pziy++QAg5OTm1bNny8ePHxggILFt3v16n4rc++CDUCI9VhQt3Wfv8aRN0XOZNYQb8aPe0w9IjTH4GalU1Gp1M/+hLdLaB44Jcogofai6lOS3eyHUQE6bn3S6TyUiSTE5Obt++/bO3Jycn29jY1Pxbo9EoFApjBASWDSfwPl//ZpzHKi96PDk7c1RGTHX2aiuvvpIewSLXzoY4E/3dk/SkFPqvENOegfPdk3RwM2xCW7gEi2PKmK3W/UfhUjnXQUyY/iKMjIxcsGBBQUFBeHi4g4NDXl7enj17fvrpp08//RQhlJWV9fjxYw8PD6OnBcCAMJFE4hMi8Qmhywo1F46X7v4RISTxDpT0CCYdGnOn009+xIB4avlFenl3U52Hc+015moJe3oo7BLlmC73H92963YTP+I6iGnT/zresGEDy7LLly9ftmzZv+NI8v3331++fHnNvw8cOODm5ma0lAAYE2HjaB0caR0cWZ2fo8lILlj9IWnrKOkRLOkR1Ch/dwtwdCCE7HmQcrdlItuY3hZVRiH730v06aGkFfQg15SHt8gHT8aEIq6DmDb9L2SpVBoVFbVixYrMzMz8/PzmzZt37drVycmp5t527dq1a9fOiCEB4IbAqZUiYrpiyNSq25fVGUnlR3YKXd2lPiHiLn5vOJejvQgdCCEGJVCdbLAudqa0h7S0Co07Rv/Sm2hjbUqxzVLl9XN0ebG0ZwjXQUxefW/mli1btmzZ0mhRAOApHBe17yZq342pVFdmnq44FVe6b61V1z5veBDRyx77oRcx7Ch9bhjpYCLXSbIITU+jR7bGRrY2vQ1Zc8OyythtiogZCDfVHez8UWcRlpSUbN68+dKlS/fv33d2dvbw8JgxY4azM5yeCywXLpY+dxDxjx8Qjku6Bbz2QcSJbvjfxez441T8IJI0hWZZeZnJ17J7gmGXKPfUGUm4SGzl4ct1EHOg/8138+ZNT0/Pjz/+OCUlRaPRnD179vPPP3d3dz937pyR8wHAQzUHEZ2WbLKftpSt1hWs/rBg1fsVqQcZdXlDv9V3PQkBjj7JMIGlF9Py2R+v0ruDCKEpdLZ5Y6t15fE7FBHTuQ5iJvS/omfPno1hWHp6+oMHDzIyMrKzsy9dutSsWbMpU6awLGvkiADwVs1BxGZfRikipuse3Mr/enrR719oL51gaeoVvwOOoV2B5KEcdstNxqBR31CBFk06Tm8PIFvJ4NAg9yrSDglbtBO6unMdxEzo2cWhUqlSU1P//PPP3r17P7nR09Nzy5YtPXv2vHPnDpwvCsBz3uwgoq0IHR5IBMRSHraYjyMfa4Zh0aQUanoHbFBzPsazNIy2QnX8gOPc77gOYj70FyHDMK6urrVub9u2LUKorKzMGLkAMEF1HkT0Ca5/+quONtiGPsSIJPrcMKKZhHdls+wiTTHos25wUgYvqI7utvL0FzjBmYyNRs+u0SZNmsjl8v3799e6ff/+/QRBtGnTxijBADBhTw4i2k1ayGhUhavnF6xZUP9BxGGt8BntsTHJtI5nu0iTH7Gb/mF39ScJ3hW0JaKVxeqzifKBE7gOYlb0bBGSJDlnzpyvv/76wYMHY8aMadasWWFhYUxMzK+//jpp0iQ7OzvjpwTARAlbtBO2aKcYNrPyeoYmI6k8Yae4U3dZ32FC184vDl7WnbheRs87Tf/Smy/bXg/U7Fsp1J4g0lnCdRSAEEKoPHarzH8IYePAdRCzov806K+++kqr1a5fv37Lli01t+A4PmnSpPXr1xsxGwBmAiNIqy5+Vl38GE2F9u/Uok3Lm7z/Pdm0Re1hCG3pR/hFU7/dYN7pyP2pmRSDxh+nP/Ag+jrBxiAvVOfdq8w633TJJq6DmBv9RUiS5OrVq5csWXL27NnCwkI7OzsfH59mzZoZORwAZgaXyKS9hyCCKN76dZP5P2GC2ov4yQQoeiDhH011VGABzhzXz6IMWiFAH3tyX8mghvLwJusB43AxbJ43svoujHV0dIRl6AFodFLf0KpbV5QHN9iMmfviva7W2PZAcsJx+swwooWUsy48nMscyGYvjCBhY5Anqu5kUvm50umfcx3EDD0twtLS0tzc3Jf+h65duxoyDwAWwTby/cer3tdcTJF4B7547wAXbJ4HPiyRTo8gJVzM4pJTwc48Qf81gLSHyZx5gmWVhzfLw6dhpImvY8lLT99kBw8enD795fMUwAX1ALw5TGRl99aiot8+E7bqSNo7vThgoSd+qZh9J53eEWjsE2eqaDQqif6sG+HXBLYG+UJ7OZ2trpJ0C+A6iHl6WoQDBw6Mj4/nMAoAFkXYop18wNiSbd84zvtB71oWm/oS/WKoH68yH3oY9SjdvNN0Wzn2Xmc4NMgbDK2M32EzcrYhlokG6NkidHFxcXFx4TAKAJZG1m941e0r5bFbFUPffvFeKxIdCCF6HaI6KrDBLYz0Cbj7DnMsjz0/HKbV5pGKU/GkraO4gzfXQcwW/NEHAHcwzHb8Au2lE9qrZ/Te31KG7Q8hp6dRt8uNcUjippKdd4beG0TI4TgUb7BVWlVilCJ8GtdBzBkUIQBcwiUyu8mflu1bSyuL9Q7o3RRb2o0YmkiXVxs2iZpCI5PoFT6Elz3sf+MR1fEDonZeguYww7MBQRECwDFh647SPuEl21cgRv/sau91xvs4YVNSaINuFb53ku7liE1rD58JPMJUKCtORMsHv8V1EDMHL3oAuCcPGYeRgvLEqLoG/OxPFFexX/9tqHlIN9xgLhSxa/35MrUbqFGesPO1l30Grw6KEAAewDC7txaqT8dX3byk934BjvYGk7//wxzObfwuvFLCLj1P7w0mOLlmEdSFKs7T/J0qHzCW6yDmD4oQAF7AZTZ2kxaW7PofrSrVO8DJCv0VQrx9gr5W2pi7SFXVKDKZ/tGX6GQDhwb5RRmzxTpwJC6z4TqI+YMiBIAvRO26SnxCSqN+QHVMW+HtgH3fixiZRJfpGucRWYSmpdEDm2MT3eCjgF90uTd1d6/JAoZzHcQiwKsfAB5RhE1mKjWq4wfqGvCWYx6JRQAAIABJREFUGx7aHBubTDXKmTOrrzK5Fez/esKhQd5RxmyWh07ChGKug1gEKEIA+AQn7Kd8UnH8gO5eVl1DfvAlMAwtPU+/4UOdK2RXXqb3BBEi6EGeqczKoMuKpL0Gch3EUkARAsAvhI2j7bgPird/y2hU+gdgKKo/uS+b3X3n9U+cKalC447Rv/YhXK3h0CDPsKwydqsiYjrC4S8UI4EiBIB3xO69rDz8SvesqWuAnQj9GUK8f5q+UPQ6e0gZFk1Koca2wYa3gk8A3tFkJGGEwMrDj+sgFgTeBgDwkWLo21RxvvpkbF0DPO2w3/oQo5PpwsoGf/NvLzNlVejL7rDBwTtstU6ZsEMxbCbMr21MUIQA8BFGCuynLlbG76h+eKeuMSNb4+PbYCOTKF1DdpGm5LHrrzP7ggkBvPv5p+JEtNDFTdTGnesglgXeCgDwFOnQzHbUnOKt37BV2rrG/LcHYSNEH5991RNnHmvRWyn01gDCRQobHLzDaCtUx/bLh0zhOojFgSIEgL+suvUTtXEvO7C+rgE4hqL6k0kP2Y3/vHyrsObQ4KyO+AAXaEE+UiXtteriJ3BqxXUQiwNFCACv2Yyao8v9R5ORXNcAawH6cwCxOINOz3/JiTNLz9MsixZ7wbuej2hlsfpMgnzQBK6DWCJ4SwDAa5hQbDd1SdmhDdTj+3WN6aDAdgSS447TD9V1dmHcfXbXHfaPIJKArUFeKo/bJvUPI2wcuQ5iiaAIAeA7gVMrRdiU4q1fs9V1Tq02qDn2bid8dDJdpe9w4X01OyON2hVIOMJEJbxEPb6vvXbWuv9oroNYKChCAEyA1D9M0MxVeej3esYs9sJbybBZ6bWbsJpB44/RH3sSfZxgY5CnyqI3ygeMwyUyroNYKChCAEyDbeR/Kv+5qL1ysq4BGEJb+hFXS9mfrz934sxHZ2k7EfZhF3iz81TV3atU3j1p73Cug1guHq0/NmDAgGe/jIyMnDlz5rO3JCQkrFq16smXP//8c/v27Y0UDgCuYSIru8mLin77XODSlrR30jvGikR/hhB+0VRnW6y3PUIIHcphonPZC8NJ2BjkLeXhzfIhUzBSwHUQy8WjIlyxYkXNP6qqqkJCQhYtWlRrwKNHjyiK+v7772u+bN68uVHzAcA1YYv21iGRJdu+dZy3CiP0v3lbybAdgeT4Y1TqYEQzaFY6HTeItBMZOSl4VdrL6ayuUuLdn+sgFo1HRdi9e/eaf+zZs6dp06ZBQUEvjrGxsXkyDAALZB0wQncnszxuuyJiel1jgpthn3QlxqXQDIst9ya6O8DWIF8xjDJuu82Id2BCNW7x8bDB5s2bp02bhuN6sp05c6Znz55DhgzZt2+f8YMBwD0Msx2/QPN3SuW1s/WM+sAD72qHutiyszvx8T0OalRlHCWsbcQd4Y97jmFsHWthG0JGRkZubm6tG+3t7QMDA598+eDBgzZt2ty6datVq9rTK1y8ePHBgwctW7b8+++/FyxYsHbt2okTJ+p9IHd395ycHIHg333ucrn88uXLJMnx5m9FRYVMZj5nhWk0GrFYrPfvFRNlQk8QlZOl2f2D7N2VuNyurjE6nY5lWZHIfPaKmtAT9CpYXWX5j+9LJ31CurTlOkvjUKvVEokE49nWrVgsfumHv1G74ezZsydOnKh1Y4cOHZ4twk2bNvXv3//FFkQIeXt7e3t7I4S8vLwKCwu3bt1aTxEuWLBgxIgRNV8KBAI+vH9YluVDjMaC47iZFaEpPUHuPnifiKq/1jvO+bauvWrmV4Sm9AS9AuWRaIFrZ5sOXbkO0pikUinfivBVGLUI586dO3fu3HoGsCy7ffv2b7/99qXfSqFQaLV1zkSM47hUKrW1tX2dlACYAvnA8YV3MssT/4BJuUwRU6FUpx20nr2C6yAAIb4dI0xKSiorKxs2bNiTW/Lz8+fMmVNZWYkQOnbsWGlpKUIoKyvrxx9/HDx4MGdBAeAchtm9tVB9Krbq1iWuo4AGKz+yS9IjCLdrynUQgBDfijAxMXHOnDnP7sxRqVQxMTHV1dUIob/++qtly5ZWVlaBgYFDhw5duHAhd0kB4B5hbWs7fn7JrlWMupzrLKABqOJ8zcUU65CxXAcB/zLqyTKNQqfTCYXC+seMGzduxIgRY8fy63WmUqmsra25TtFozO9kGRN9gpSHN1U/uucw68taBwvN7xihiT5BLyre9o2wWRtZyFiNRiOVSrmO02gqKipM9Bih6X2KvbQFAbAoiiFTmUp1RepfXAcBr0SXe1N395osYDjXQcBTpleEAIDn4IT9lE9Vyft0925wHQW8nDJmszx0EiaEdUB4BIoQAJNH2DjajvugZOdKplLNdRZQn8rrGXRZkbTXQK6DgOdAEQJgDsTuvcQdu5fuXs11EFA3llXGblVEzEA4wXUU8BwoQgDMhGL4O1TRI/WpOK6DAP00GUmYQGDl4ct1EFAbFCEAZgIjBfZTlyjjtlU/vMt1FlAbW61TJuywGTYT5tfmIShCAMwH6dDMZtSc4q1fs1V1zrsEOFFxIlrY3E3o6s51EKAHFCEAZkXSLUDo2rnsz1+5DgKeYrQVqmP75WFTuQ4C9IMiBMDc2I5+r+peVuXFFK6DgH+pju628vQXOLXkOgjQD4oQAHODCcX2Uz6tiNlEFz3iOgtAdGmB+myifJD+pXIAH0ARAmCGBM1cpaGTlZuX02WFXGexdMr4HbLeQwiFPddBQJ2gCAEwT1Y9B1j5hxf+/AmtLOY6i+WqzrtXlXVeFjSG6yCgPlCEAJgtqz4Rst5DCtcthC7kijJ6o/WAcbhYwnUQUB8oQgDMmSxwpNQ/rPDnRXR5CddZLE7V7Uyq4IHUP4zrIOAloAgBMHPW/UdJvAMLf15El5dyncWSsKwyZpM8fBpGCriOAl4CihAA8ycPnSTx6lv062JYwtdoNJfSEM1IvPpxHQS8HBQhABZBPniylbtv4fpPoQuNgKWp8thtiojpMKGaSYAiBMBSyIdMEXfqUfjLp4xGxXUWM6c+GUs6uojae3EdBLwSKEIALIgifJq4g3fh+k8ZTQXXWcwWW6VVJe1RDJnKdRDwqqAIAbAsivDpItfORRs+g4m5DUSVvFfUsbugeVuug4BXBUUIgIXBMJuR7wqbty38dSl0YaNjKsoqTsUpBr/FdRDQAFCEAFgeDLMZ9Z6gWeui36ALG5kybru05wDCtgnXQUADQBECYJEwzHb0XNKpVdGmL9lqHddpzARV8EB7Od06OJLrIKBhoAgBsFQYZjvmfUJhV7xxGXRho1DGbLYOjsSlcq6DgIaBIgTAgmGY3fgFuMymeNNy6MI3pMu5ocu9KesTwXUQ0GBQhABYNhy3m/gRLrEu3vwVS1VzncaEKQ/9rgibgglFXAcBDQZFCIDFw3G7SQtxsaRk+7csTXGdxiRpM08zWrWkRzDXQcDrgCIEACCE47aTPkYMU7J9BWJortOYGoYpj92qGDoD4fCJapLgaQMAIIQQRpB205ayVHXxNujChlGfPYLL5OJOPlwHAa8JihAA8C+MIO2nf8ZWVxXvWIkYhus4poGt1pUfiVKEz+A6CHh9UIQAgKcwgrSftpRRl5fs/hGxLNdxTIAq5YDItbOwdUeug4DXB0UIAHgOJhA6vL2cLi0o3b0aurB+jLq8IuUv+ZApXAcBbwSKEABQGyYUOcz8kirOK90DXVif8iO7JN6BpEMzroOANwJFCADQAxOKHGb9X3t3GtfEtTYA/CQkYSckEHZQQHBDhSKIiIpsCgXRKgpuuFSpuFWlblivQivaSutOASuiaNG64ArIpogFUWRzBQEBSdhJSISQhMz7YXrzcgERJDAJnP/PD5mTMzNPMoYnMznznCBBHb3pynGYC7slaKxpyUlTdvHBOhCov2AihCCoeziSnNraA3x6GTMuHOtYJFHznSilGfNklClYBwL1F0yEEAR9El5OQX39z7yyV8y4CKxjkSz8qtK2d/nK9vOxDgQSA5gIIQjqCV5OUX39QV7JC9bNSKxjkSDMm5Eqc5bjZOWxDgQSAwLWAUgKBEGYTOaA7oLD4QgEQ6d+VWtrq6ysLF6qSmmQSCRFRUWso5A+eHkldf+Ddad24eIvqMApZwHgvslpb6pVmOKCdSCQeMBE+K/IyMgtW7bIy8Pvd0MZm81+/PixtbU11oFIH7y8Eu27n+tO7QR4GZXZS7AOB1MIwroTRfZYg5OBfz+HCHgg/8XhcPz9/UNDQ7EOBBpAjo6OHA4H6yikFV6JTNtwqO7kToDHqTgP36GSLc9ScTIE+QlTsQ4EEhtpuq4FQRC28Eqq6hsOteaksZMvYx0LNpB2QXNCDNljNcDhsI4FEhuYCCEI6gMZZYr6hsMfnyazU/7GOhYMcNJvEnVGyo6aiHUgkDjBRAhBUN/IKFNo60M+Zt7jPLqFdSyDStjKYaf8rfL1SqwDgcQMJkIIgvpMRlWdtvEXzoMbnIw7WMcyeNjJV+TNbIhaI7AOBBIzmAghCPoSMqo02sbDnLSrHx/fxTqWwdDOaviYlaAyZynWgUDiBxMhBEFfSIaiob7+YHNS7MesBKxjGXDN984rTnWVUaVhHQgkfjARDkGZmZmNjY392UJqaiqPx+vrWh8+fHjx4kV/9tutsrKyN2/eiH2zkFgQ1HVom4+wky9zHt7AOpYBxK+p4L7OVnZahHUg0ICAiVDicDgcKpVKpVL19PSmTZu2atWqzMzMPm1hw4YNeXl5/YnBzc3tC1LpzZs3Q0JC+rPfbsXExJw8eVLsm4XEhUDVpG04zMm405x4EetYBgrr5hllx8V4OViWaGiCiVDiIAjS1NT04MGDgoKCP/74w9DQ0NnZ+fLlPty2lZaWNmPGjIGLEII6kaFo0DYdac17xLp9FutYxK+tpFBQXa447WusA4EGCkyEEopMJlOp1AkTJuzbty8kJCQgIABBEAAAg8FYvny5qampra1tfHw82nnPnj3nzp37+uuvR4wYwWQyAwICCgsLGQyGu7u76ApnYWHh0qVLAQCZmZlz5swxNDS0tLT8448/RHu8dOmShYWFmZnZxYv//73+4sWL06ZNGzly5IwZM5KTk7vGyWKxfH19jY2N586dy2AwRO35+fnu7u6jRo1ydXUtLCxEGxctWnTlyhVbW9upU6cCADIyMpydnUeNGjVv3ryysjK0D51O9/X1HT169IQJE44dO4Y2crlcf39/9DvBu3fv0Mb//Oc/FhYWxsbGnp6eRUVF/X/Pof6QUaHQNhzmvslh3TozpOYvRBDW7bMq7qtwBCLWoUADBhmKFi9eHBsb26dVQkNDt23b1rGFK0AauYPxjyv4n0iam5sBAO/fvxe1oH/l3717x+Pxxo0bd/To0ZaWlqdPn2pra7958wZBkDlz5hgZGWVmZjIYDD6fb2FhkZKSgiCIhYXF9evX0Y1s2bJl69atCII8f/48Ly+vra3t5cuXJiYmDx48QBAkOztbTU0tOzubxWItW7YMh8MxGAwEQVJSUkpKStra2lJSUjQ1NWtrazu9bz4+PsuXL29ubs7MzNTQ0FiyZAmCIHQ6XUND486dOy0tLdevX9fX12ez2QiCaGpqzpgx4+3bt3Q6/dWrV5qamunp6S0tLREREePHj+fz+W1tbWPHjg0MDGxqaqqpqXn48CGCIEFBQcrKyrdu3WIymVu2bHF3d0d3HRcXV11d3draeuzYMQsLi94cZQcHB/Sd6VZzc3NvNiIt2trauFzuIO+0vYVd8/uWxsvHEKFQ7BvH5AC15KZX/7J+IF6OUCjkcDhi3yyG2Gy2cADeqEEAa41+0p5n7VFFwkHY0WpT/JEpMj100NTUBACwWKy0tDQcDrdixQoul4uehMXFxe3cuRMA8O2339rY2HRa0dfXNzo6ev78+QKBIDY2NjExEQBgYWFRXl6ekJDQ1tY2bty4Bw8ezJw5MyYmZuXKlVZWVgCAn376KSYmBt2Cg4NDYWHh3bt3BQKBurp6Tk7OnDlzRNvn8XhXrlyprKxUVla2sbHx9vaur68HAFy4cMHBwcHW1pbL5drb2+vr6//zzz8uLi4AgN27d5uamgIAfvnlF29vbzMzMy6Xu3DhwsOHD7969aq6uprH4wUHB+NwOACAhoYGuqPZs2d7eHgAANatW+fs7Iw2enh4ZGZm0ul0LS2tFy9eMJlMVVXV/h4MqH/w8ko0/0P1kfsbY36lLt0O8D39x5Z8SLuAdfccxWsjLKg2tMFE+EmhU2RCe8xPg6aiogIAoKmpmZOTU1NTs2jR/w9dmzjx31JPBgYGXVdctmxZYGBgTU1NVlaWjo7OpEmTAADh4eG//vrr3LlzNTU1ORwOOiiGwWDY2dmha+nr64smV1q7dm1+fr6TkxOZTObz+Q0NDR23X1NTg8fjtbW10cURI0agibC8vPzJkyeiOBUUFJD/XivT19cXvahXr169fPkSXTQ0NGxra6usrDQyMsJ1+aODfhVAN/Xx40cAQGtr68yZM7W1tc3NzRUUFPB4fGNjI0yEkgBHklNfe6DhbFDjhV8oy36Q6ikaPmbGE9S0ZE0tsA4EGlhS/H90+Lhw4cLEiRN1dXUNDAyoVOr9+/e7poquLQAANTU1FxeX2NjYhw8f+vr6oo3Hjx8/d+4cmvZEeUhHR6e8vBx9XF5eLhQKAQDNzc3R0dEsFgudnSoqKqrT9jU1NYVCIZ1O19HRAQC8f/8ebTcwMLCysup2gI8oxerr6+vr6x89erTjs0wms6SkRCgUfnaaw4yMDARBbt68CQBoaGjYtWtXz/2hwYQjyaqtPdB47mDD2WC1lYE4IgnriL4E0tbKvv+X+rogrAOBBhwcLCOhCgsLHz9+HBMTs2DBgsjIyIiICACAg4ODrKzs7t276+rqGhsb4+PjReNQPsXX1zcsLOz+/ftLlvw7hxyVSk1PT29tbb116xaaSAAAy5Yti46OzsrKampq2rt3L5qH5OTkSCRSeno6h8M5fPiwKM+JkEgkb2/vHTt2MJnMx48fizLfihUrUlJSoqKimpubGQzGxYsX0TPFjvz8/M6fP3/9+nUOh/Phw4fIyEgej2dvby8vLx8YGNjQ0MBgMB48ePCp10WhUMrLy4uLi+vr67ds2UIgwK90kgUnQ6Cu3IMjkBrOBiH8Pt+TKgnYaddkTc2JeqOwDgQacDARShwCgeDk5HTs2LGgoKCEhAQ7O7s3b95MmTIFAEAkEpOTk5lMpqOj4/Tp06Ojo+Xk5AAAFhYWWlpaoi3Y2NhQqVT0sZubm4mJib+/P432b0WMU6dOJSUlTZgwIS4uLiQkBP3FbvLkySdPnty0aZO9vb27u/vs2bNJJBKJRLp06dLu3butrKy4XO727dtFV0FFTp8+TSKRpkyZcuTIkeDgYDMzMwCAtrZ2RkZGQkLClClTZs+enZ6eTiKRAAAzZswQTRA/duzY+/fvR0dHW1pazp0798WLF3g8Hn2B1dXV06dPd3V1RU9YjYyMRo8eja4lLy9vb2+PBrx9+3ZPT08XFxd3d3d3d3c4qbKkwckQ1Hx3yyhT6v8IRNpasQ6nb4QcJufRLRXX5VgHAg0GHDKUBjr/l7e39/z58xcvXtz7VX777beqqio4Me/Q5ujoGBgY6ODg0O2zbDZbWVl5kEMaODweD0EQWVlZjONAEOb1MN77N+rrf8Yr9OvtHcwDxPz7JI5IIs9bN3C7QBCkpaVF9NVwCOBwOIqKit3+TCPh4BkhBEEDCYdT/WY9ydis7vQu4cdmrKPpFUFdVUteurKzN9aBQIMEJkIIggYYDqc6b5282dTa4wHtrIbP98ca606UssNCvKIK1oFAgwQmwiEoLS2t6+CUPrl27RqXy/2ydV+/fv3ZITxdhYeHHzx4sDc9k5KSmExm3+OCMKYyZ5mC5ay6Uzvbmf36zzmg2pl1jTG/8OllSjPmYR0LNHhgIpQ4oqLbGhoa5ubmixYtSktL69MWtm/fXlBQ0J8Yli5d+sXJ5q+//jp7tm8FJ3Nyci5cuLBlyxZ0MSMjIzw8/FOd169fX1xc/GWxQdhScfFRmuFZd3y7oJ7x+d6DC+G1sVOu1BzZJENW1ww4KaW3fEBfBg46lzgIgjQ1Nb1//15HR6eiouLGjRuenp4nT55csWJFL7eQlZWF4e0E+/bt6+sq9fX1169fF40aeP36dVJSkp+fX7edX716RSTCqo/SSsnOA4eXqTsRoL7+oKRM9Y4grfkZrFtniAamGtuOEaiaWAcEDTZ4Rii5iESisbFxQEDAL7/8snPnTvQm9/Ly8gULFhgYGHz11VfXr19He27atOnUqVMODg5qampMJnPNmjXPnz+vqqqys7Nra2tD+zx//tzd3R0A8OjRIzs7O11d3TFjxvz222+i3Z05c2bMmDGmpqZnzpwRNUZFRVlYWGhra1taWt65c6drkLGxsWZmZrq6umZmZmiHP//888SJEwCAZ8+e+fj4BAUF6enpmZmZ/fPPP5cuXTIxMTE2Nhbdccjlcnft2rV58+Zp06YFBgby+fx37979/PPPqampkydP9vT0BACsXr06PDx8+vTpampqfD7f29v79evXAACBQHDo0KEJEybo6Og4OjqiNVp9fX2NjIz09fXnzZuHVuSBJI2irRt57rf1YXv49DKsYwFtxfk1oRvZadeoy3eqrQyEWXB4gmeEnyTktgg/sgZhR3hFlZ7nOXNyclq/fn1paamBgYGLi0tAQMDly5eLiopcXFxGjx49fvz4d+/eJSQkXLt2zcjISE5O7uXLl83NzZMnT+bxeLdu3fLy8gIAnD17dty4cQAACoUSFRVlYmJSXl7u6uo6adIkR0fHf/75JzAwMC0tzcjIyN/fXzRnhampaWJiooaGRmZm5rx58woKCkTVzgAAra2t3377bU5OzujRo2tra1ksFgCgqqqKzWYDANhs9tWrV0NDQ0tKSk6fPr1o0SJPT8/8/PwnT57Mnz/fw8NDQUEhICCgsbHx6dOnCIJ4e3sfO3Zs69atW7duTUlJiY6ORu/rf/v2bXZ29t9//62rq0sgEAoKCtAqa4cOHbp169bt27f19fVzcnJkZGQAAN7e3uHh4TIyMiEhId999929e/cG6KhB/aFgOQuHl6k7vVt97X7SiDGYxCCoq2LdPccrf0t2W6Ew2RFWEx3OYCL8JHby5dbc9EHYkbz5dLLH6h46oPfCNzc3p6am4vF4R0fHiooKOTk5Z2fn27dvjx8/HgCwdu1aUd1REbTotpeXF4/Hu3z5cmpqKgDAzMysqKjo0qVLHA5nxIgRjx49cnR0jI2NXblyJZopDxw4IKqmNm3atKysrISEBC6XS6FQcnJy3NzcOu4Cj8enpqaqqalpaGiIamSLaGpqbt68GQDg4+Ozbdu2ffv2KSgozJo1S1FRsaysbMyYMWfOnElOTkaH9ixdujQsLCwgIEBBQYFEIlEoFNF2Nm7cOHbs2E4bj4yMPHfu3MiRIwEA1tbWaKO9vX1KSgqDwVBUVHz06NFn33wIK/IWM3Cycg1nDqit/pFkOG4wdy1s4bBTrnzMSlCaPpe69Af4cyAEE+Enkd1Xkd1XYR0FAACgVUC1tbVzcnLq6+s7/ng2efJk9IGurm7XFX18fHbu3FldXf348WNDQ8MJEyYAAI4dOxYWFubt7a2mpkYgEJqamgAA1dXVoqLburq6olKfy5YtKy8vd3NzU1VVFXUWkZeXv3XrVmho6I4dO8zNzcPCwtDKMiLq6uqinp0WW1pa6urq2tra9u/fL7oD18jIqNt3oOurQxCETqejWVCkurp66tSpzs7OpqamRCKRw+Hw+Xz4g6LEkhtnTfXd3XA2mLp8x+AUtkbaBS1P7jcnxMiZ2WjuCpdRpnx+HWgYgIlQCpw9e9bS0lJbW3vkyJFkMjkxMbFrTepuqzlQqVQ3N7eLFy92LLodHh5+9uxZW1tbAEBWVhbaqKenJ5oat6ysTFR0+8qVK2w2W1ZWFkGQjj8oitjb29vb23/8+PHHH3/csWNHny5FamhoKCgoHD9+HD0TFZGRkUED6OHV4XA4AwODt2/fGhoaihrv3r1raWmJ1mXNycnpfSQQVmRHTaSuCmw4G0zx3ipv1nkeMfFqK8plXv8Dr0JVX3+QqD1yQPcFSReYCCVURkbGq1ev0FGjubm5CQkJAIBZs2aRyWT0VzQCgZCVlTVq1Chzc/MetuPr67tly5aamhrR1U4NDY2EhAQTE5OUlJS7d++iCdLX19fBwcHd3d3U1HT37t1oopWXl5eXl793756tre3p06erqqo6bZzBYMTHxzs5OcnLy7e1tYlO+HoJj8dv3bp17dq1x48f19fXLyoqqq6uXrhwobGxcV5eXnp6OpVK7XSK2dH333+/fft2VVVVQ0PDp0+fzpw5k0aj5efnFxcXIwiyZ8+ePgUDYUXWyEzdL7ghcj9oF8hPshuIXfBrKlg3IwUN1apzv5UbP2UgdgFJNZgIJQ6BQPDy8kLnhaBQKPPnz4+NjUVn2iMQCMnJyT/99NPixYuFQuHEiRMDAwMBANOnT+84H+GsWbNEJbZnz549depUU1NTNTU1tOWPP/4ICAhwdHScMWPG8ePH29vbAQCTJk2KiooKCgri8/k7duwgEolycnJEIvHKlSs//fRTcHCwj4/Pjz/+OGLE/4x3J5FIGRkZYWFh7e3tNjY26JxKY8eObW1tBQBoaGiIJtElEoleXl6iEztXV1e0LHhQUFBERMSuXbtqamqMjIzQq74zZszYsmVLeHg4lUo9ceKEg4MDOs0TytnZGf35cNOmTQoKCnv37q2trTU3N7e3t/fw8Hj27JmXl5e6uvqOHTvIZPJnp3OCJAFJ31TdL7g+fC/C4ypYOYlxy8KPzc2JF1ueP1Rx9laa7iHtEwVDAwQW3f4XLLo9HMCi25JMUFNZF7ZHZc4yRZvZ3XbU2xr5AAAT3ElEQVTo0wFC+DxOehw79aqC5SwVtxU9D8zGBCy6LTkwOCPk8/kvX77Mz89XVVVFbxRDCYXCS5cuFRYWmpiY+Pr6djvGITs7Oy4uTklJadWqVV2nBIIgSHoRNPVpm36tP70baWtVmtmPCmfoDfK3/yRojdDYdoygBv9QQJ+BwYWjo0ePzps3LzQ09PDhwx3bt23bFhoaqqenFx0d3W0VlaSkpNmzZ6uqqlZWVlpZWXUawQhBkLQjqGnRNh7mPLrVnHjpy7bAq3hbezyAnfI3ZWmA+toDMAtCvYHBGeG2bdt++OGHqKioyMhIUWN9fX14ePirV68MDQ2XL1+uo6NTXFxsYmLSccVDhw7t378frUhZWloaFRW1bdu2wY4egqCBJEPRoG0OrQ/bjfC4Pd9f20k7s45191xbcb6KyxLFqa7wBnmo9zA4I0QrgHSSlZU1YsQIdCi8qqqqlZXVw4cPO3YQCoXp6emzZ//744GLi8uDBw8GPlgIggabjAqFtuEQ980z1q0zn+8NAMLjNifE1Py6QUZFTWt3pKKtG8yCUJ9IyqhRBoMhGugIANDU1KTT6R071NfXCwQCUe0STU1NBuOTBewrKyvDw8OTkpLQRXl5+UOHDnWbgEUEAsGXRw9JCQRBeDzep2aY4nK5Q+nue3SwjLSOhiPIKX8b1BwVxI89quTphya2bg4QgrTlPvgYf55oMkn1+2N4ZUobAsCXziA2yBAE4XK5Pf9dki7oy5G0wTJEIvGzb/KAJMKTJ09u3bq1854IBHRUffdxEAjoOH5U14Ig6HQKonQlEAh6+JulqKg4YsQIS0tLdFFeXl5WVrbnwwPH2Q8HOByOQCB86n8OkUgcSokQzYJS/IqIFPXvDjaeDfp49biq91aAl+l0gHjF+aybEXhFFbV1QQSd7msSSTL06EjxAeoCfTmSlgh787d9QBLhxo0bN2zY0Kmx53dHR0en4ykgnU7vVFWLQqHIycnR6XT0pJBOp3e8t6wTKpXq5OTUp9sn8Hh8TU0NLEcytLHZbDwe/6mvhzIyMkPp67mMjAyCINL9ihSUaOuCG/48wPorlLL0B9EBEtR+YN2L5leVkr9eKW8+HesovxB6dKT7AP0v9OVIWiLsjYG6NNrX98LOzo7FYj19+tTKyqqsrKywsNDFxQUAwGAwGAzGV199hcPh3N3dr169am5u3t7efuPGja65tj9MTEwuXbr0qTnwxEIoFA6l804EQaTufzwOh+vh+xMkgXAkWbW1BxqjQxrOBpMWbBa2sNkpf7dkJynZz6cu24EjDJ3TKQhDGPxGmJ2dHRgYSKfTq6qqnJ2dbW1tDxw4oKioeODAAU9PTw8Pj/v372/fvl1LSwsAEBcXFxERkZubCwDYu3cvOvFCeXk5Ho/v0wnfZ3l4eHh4eIhxg10Nsfu1W1pa5OTkhlJqhyQTjkCkrtzTeP7Qxz//w2HVKVg6aO6OwCsMnY8ShDkMKsuwWKx3796JFlVVVY2NjdHHBQUF+fn5Y8aMsbKyQltqampqampEEwzV1tYmJyeTyWRnZ2cS6ZOTp3xBZZlBABOhhBtiB0jqKst8hrC9Pu2G6sSpBFo3E61II1hZRnJgcEZIJpNFw1g6mThxYqdJ9TQ1NTvOBKuhobFkyZKBjQ+CIAmEl5G1nk0YQt9UIMkxdL7OQxAEQdAXgIkQgiAIGtZgIhwkbDY7IyMD6yjE6dmzZ7W1tVhHITYIgiQmJmIdhTi9e/fu7du3WEchTvfv3+94t7G0a2hoEM2MPTRkZmYymUyso/gSMBEOkpycnJCQEKyjEKcTJ050KoMn1RobGwf05pnBd/Xq1djYWKyjEKfNmzdXV1djHYXYPH78GJ3Cc8j49ddfpTS1w0QIfTlpLd81PMCjI+HgAZIcMBFCEARBwxpMhBAEQdCwhsEN9YPA2tqay+V2vAERc01NTaWlpZ+6gVIaFRYWamhoSNSb3B98Pv+ff/6ZOXMm1oGITVlZmVAoFFWrGAIePXpkbW09ZEoE1NXV0en0SZMmYR2I2OTm5hoYGKipqWEdyP+YP3++v79/z32GZiJMT09nsVjy8vJYB/L/BAIBg8HQ19fHOhCxqa6uJpPJEvUm91NZWRk6I+bQwGQyhUIhlUrFOhCxKSsrGzlypDQWLulWW1tbQ0PDUCp+W1VVRaPReqj5hQlDQ8PPfh0cmokQgiAIgnoJ/kYIQRAEDWswEUIQBEHDGkyEEARB0LAGEyEEQRA0rMns378f6xiGBT6fn5+fX1xcPGLEiE5PIQiSlpbG5/Mlbdhxz1paWp4/f15dXd1x2BuDwUhKSsrLy5OXl5eu8YoIghQXF+fm5mppaRGJ/z/veUNDQ1xcHHrgOrZLlxcvXiQkJFRUVOjr60vvq+ioqqrq9u3bL1++VFZWVlVVxToc8Xjy5Eltba22tjbWgfQXi8VKTU3NzMxEEASdYl3SIdDAS0xMlJWVVVdXp9FoXZ+NiIggEAjff//94Af2xU6fPk0ikahUqp2dnagxKSmJQqF4enouXbqUTCYfP34cwwj7pKGhgUwmq6urAwDevHkjai8uLtbQ0PDx8ZkzZ87YsWOZTCaGQX6xn376SUdHZ8uWLe7u7vr6+lVVVVhH1F9//fUXlUpdsGDB0qVLv/nmG6zDEY+MjAwSieTk5IR1IP1VUVGhrKzs4uKycuVKLS0tf39/rCP6PJgIB0NjY2N9ff3Dhw+7JsKqqqqJEyf6+PhIVyKsqalpbm6OjIzsmAjRRvTxnTt3lJSUBAIBRgH2DY/He//+vVAo7JQI165di36MhUKhk5NTaGgodjF+OQqFkpSUhD6eMWPGb7/9hm08/fThwwdFRUX0bGPI4HK5lpaWmzdvHgKJkMPhMBgM9HFZWRkOh3v37h22IX0W/I1wMFAolE9d9vT39w8ODlaWtnm3NTQ0usbcsVFbW1sgEKCpRfIRicSul6wBAHfu3FmwYAEAAIfDLViw4M6dO4MemhhQqdSWlhYAAIIgLS0t0nUFvqubN29aW1ubmpomJyeXlpZiHY547Nu3z8vLa2iUAVJUVBRdDqXRaAQCgcfjYRvSZ8FEiKXz588rKCjMnTsX60DEDEGQoKCgFStWSPXPUQKBoLa2Vk9PD13U1dWtqqrCNqQvExsb++OPPy5YsMDKymratGlLlizBOqJ+KSkpaW5unj59+p9//jlt2rQDBw5gHVF/5ebmpqSkbNu2DetAxC8kJGTKlCljxozBOpDPIGAdwBDx6NGjTZs2dW2/d+/ep0ooVVdXBwcHS+xsvTExMUeOHOnUSCKRsrOzP7tuYGBgRUXF+fPnBya0L8HhcOzs7Lq2Hzx40M3NrdtVhEKhUCgUFfSSkZERCAQDGGI/bN26NS0trVPj1KlTw8LCAABnzpyh0WheXl6VlZWnTp1atWqVhNe3pNPp3R6UkydP2tnZcbncoqKikpISGo327t278ePHL1++3MjIaPDj7L2QkJDLly93ajQ2Nr527RqPx1u9evWZM2ek61vjd99913XqwVmzZv3++++ixZiYmOjo6IcPH0p+VTyYCMXD3Nw8JiamazuNRvvUKn/++aecnNy+ffsAAI8ePSIQCCEhIbt37x7AKPvC1dXV3Ny8UyMe//lLCMHBwbdv305NTVVRURmY0L6EgoJCtweoh+qvJBJJTU2trq7OxMQEAFBTUyOxZSG3bt26Zs2aTo1KSkoAgLKysoiIiIaGBgqFAgCorq4ODQ2VqO8oXdFotG4P1siRIwEA2tra48aNQz9Zo0aN0tHRefXqlYQnwpUrV3p4eHRqlJOTAwDEx8fX1tZGREQAAF68eFFeXr5x48aTJ09iEGVf7Nq1i8PhdGrs+JG/evXqjh07kpOTJfzQoGAiFA9lZWUzM7M+rTJv3jxTU1P0cWlpKYlEsra2HoDQvpCamtoX/Jj022+/xcTEPHjwoIdvAJjA4/F9PUAAAHt7+8TERFtbWwDA/fv37e3txR+ZOBgYGHzqKRkZGQAAn89HF3k8HtoiyYhEYg8Hy9HR8dSpUzwej0QisVis2tpaya9lr62t/ambIiwtLUXz1PP5fDab7eDgMIihfSH0S8mnxMXF+fv7JyQkjBs3brAi6hdYdHsw1NTU7Nu3D73HbsWKFbq6uuiJoIifn5+CgkLHqwoSrqCg4NSpU2/evCkqKpo7d+5XX33l5+eXkJDg6urq4eEh+swfPHhQWoZmBAQEsNnsiIiIRYsWqaqq/v777woKCtnZ2c7Oztu3b29qarp48WJubq6uri7WkfbZ119/XV9f7+vrW1lZeeLEicTExGnTpmEdVL/MmTOHSCS6urpeuXKFQqHcuHED64jE4/jx47dv305KSsI6kH4pLS0dO3aslZXV+PHj0ZaNGzdOmDAB26h6Bs8IB4OsrCw6E6G7uzsAoOud5suWLSMQpOlYkMlkS0tL0fSK6OxFxsbG4eHhHbtJ0dRxkyZNam1tFcWPHg5ra+vHjx9fvXqVRqPl5ORIYxYEANy8efPq1asvX76kUqnPnz8XXYeQXrdu3bpw4UJpaamfn9+iRYuwDkdsHBwchsDAURUVlRMnTnRsIZPJWAXTS/CMEIIgCBrW4O0TEARB0LAGEyEEQRA0rMFECEEQBA1rMBFCEARBwxpMhBAEQdCwBhMhBEEQNKzBRAhBGMvNzf3rr78Gc4/t7e3Nzc2fejY5Ofn169fo47S0tL///vtTPcvKyqR0Rg4I6ggmQgjC2NWrV/38/MSyqeLi4p9//vmbb74ZPXq0sbFx1+lvOBzOt99+q6SkRCaT9fT0IiMjO3XIy8v7+uuvRVWSo6Ki9u/f/6ndKSkp+fj43L9/XyzBQxBWYCKEoKEjMTHx559/ZjAYMjIypaWlXctl+Pr6xsbGHj16NDMz083Nbd26dbGxsR077Ny5c+HChb2cN4dGo61Zs2bnzp1iewEQhAWYCCFIEnG53Orq6ra2tm6fbWpqYjKZXdt9fX2bm5szMzNnz57d9dmnT59ev3597969fn5+NjY24eHhVlZWgYGBonz59u3bpKSklStXdl0XQZC6urr29vZO7StXrszLy5PY2cQgqDdgIoQgydLQ0LB48WIymaytrU2hUNasWdNxvpuSkhI7OzsqlUqhUGxtbePj46lUanx8PPqssrJyD0Vr0W6i4pw4HM7Ly6u0tPTly5doy/nz58lkctfZD+Lj4w0NDTU0NJSUlPz8/DqmQ3Nzc2Nj4+joaHG8dAjCBkyEECRB2tvb3dzc4uPjw8LCCgoKDh06dPHiRS8vL/RZLpfr6upaXl4eFxf38uXLefPmrV69uqmpqetvgd2qqKhQUFDoOD8cOifAq1ev0MXU1FRra+tO8zTR6fRt27YdPnz46dOn33//fURERKfJAm1sbLpOCwxBUkSaZjyAoCEvMTExOzv7zJkzq1evBgBMmDDh48ePe/bsycrKsrGxuXHjRnFxcVJSkpOTEwBg3LhxHz586FTpvwdVVVWdZsVCFxsaGtDFgoICdL8dsVis1NRUCwsLAMDkyZPv3r1748YNX19fUYcxY8ZcvHiRw+GgUwFDkNSBZ4QQNHja29urOhAIBJ065OXlAQAWL14sakEfp6enAwAKCgoUFBTQLIjqOu95z3vH4//nI4+e/AmFQgDAx48fW1paus4RpqWlhWZB1NixYysrKzt2QLNpbW1t7yOBIIkCEyEEDZ7379/rdVBSUtKpQ0VFhbKycsdTKx0dHfDfk7bq6mp1dfWO/Wk0Wu/3rqOj09jY2LEF3ayqqioAgEgk4nC4rsNhKBRKx0VZWdlOV2L5fD66eu8jgSCJAi+NQtDg0dfXf/bsmWhx5MiRnTooKipyOBwulysnJ4e21NXVgf9Obaqnp1dTUyMUCkUndgwGo/d719XVZbPZ1dXVWlpaaEtxcTEAYPTo0QAAEolEJpPr6+v7+qLq6+vxeHyfUjIESRR4RghBg4dEIll2ICsr26nDlClTEAS5d++eqOX27dsAgKlTpwIALC0t29rabt68KXr28uXLvd87Ohy04+pxcXEaGhqiK59WVlaFhYV9fVEFBQUTJ04UZW4IkjrwjBCCJIinp6epqenmzZtVVVWtrKzS0tL27t1rbW1tb28PAHB3d588efLq1avpdLqpqent27c7DddkMplJSUkAgKKiIgDAtWvXiESigYHBlClTAAAODg5TpkzZv3//2LFjx48ff+7cuaSkpCNHjoiGiTo7O+/bt6+1tVVeXr6XAQuFwqysrOXLl4vvPYCgQYdAEISpPXv2KCsrixZLSkpsbGxEn1BHR0c6nS56tqamZvHixYqKioqKigsXLkRLfWZkZKDPPn/+vOtn3MfHR7T6hw8f7Ozs0HYikbh9+3ahUCh6lsFgkEik2NhYUcvy5cvHjRvXMdrly5ebmZmJFlNSUgAAL168EN/7AUGDDYd0KcIEQdBgQj+KncZzlpWV1dXV6ejo6Onp9bBuZGTkunXrqqqq0DE1vVRaWlpfX29iYtJpIAwAYNWqVZWVlcnJyb3c1JIlS5hMZsdruRAkdWAihCBp8uTJEyMjI3RkSl5e3ty5c3V0dLKyssS1/aqqqtGjR9+9e3fmzJmf7VxUVDRx4sSnT5+iN+ZDkJSCiRCCpMnmzZvDwsL09fUFAkFlZSX6S6GpqakYd8FgMGRlZbveUNgVi8Vqbm7W19cX494haPDBRAhB0qS9vT03N7e4uJjL5RoZGU2bNq2H4qIQBPUGTIQQBEHQsAbvI4QgCIKGNZgIIQiCoGENJkIIgiBoWPs/mvFDXiaMsLcAAAAASUVORK5CYII=",
+      "text/html": [
+       "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"600\" height=\"400\" viewBox=\"0 0 2400 1600\">\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip240\">\n",
+       "    <rect x=\"0\" y=\"0\" width=\"2400\" height=\"1600\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<path clip-path=\"url(#clip240)\" d=\"M0 1600 L2400 1600 L2400 0 L0 0  Z\" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip241\">\n",
+       "    <rect x=\"480\" y=\"0\" width=\"1681\" height=\"1600\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<path clip-path=\"url(#clip240)\" d=\"M287.366 1423.18 L2352.76 1423.18 L2352.76 47.2441 L287.366 47.2441  Z\" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip242\">\n",
+       "    <rect x=\"287\" y=\"47\" width=\"2066\" height=\"1377\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"484.998,1423.18 484.998,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"763.352,1423.18 763.352,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"1041.71,1423.18 1041.71,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"1320.06,1423.18 1320.06,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"1598.42,1423.18 1598.42,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"1876.77,1423.18 1876.77,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"2155.12,1423.18 2155.12,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"287.366,1367.63 2352.76,1367.63 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"287.366,1046.25 2352.76,1046.25 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"287.366,724.881 2352.76,724.881 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"287.366,403.508 2352.76,403.508 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"287.366,82.1342 2352.76,82.1342 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,1423.18 2352.76,1423.18 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"484.998,1423.18 484.998,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"763.352,1423.18 763.352,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"1041.71,1423.18 1041.71,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"1320.06,1423.18 1320.06,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"1598.42,1423.18 1598.42,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"1876.77,1423.18 1876.77,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"2155.12,1423.18 2155.12,1404.28 \"/>\n",
+       "<path clip-path=\"url(#clip240)\" d=\"M438.817 1468.75 L468.493 1468.75 L468.493 1472.69 L438.817 1472.69 L438.817 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M479.396 1481.64 L487.035 1481.64 L487.035 1455.28 L478.724 1456.95 L478.724 1452.69 L486.988 1451.02 L491.664 1451.02 L491.664 1481.64 L499.303 1481.64 L499.303 1485.58 L479.396 1485.58 L479.396 1481.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M521.595 1455.09 L509.789 1473.54 L521.595 1473.54 L521.595 1455.09 M520.368 1451.02 L526.247 1451.02 L526.247 1473.54 L531.178 1473.54 L531.178 1477.43 L526.247 1477.43 L526.247 1485.58 L521.595 1485.58 L521.595 1477.43 L505.993 1477.43 L505.993 1472.92 L520.368 1451.02 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M718.213 1468.75 L747.889 1468.75 L747.889 1472.69 L718.213 1472.69 L718.213 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M758.792 1481.64 L766.431 1481.64 L766.431 1455.28 L758.121 1456.95 L758.121 1452.69 L766.384 1451.02 L771.06 1451.02 L771.06 1481.64 L778.699 1481.64 L778.699 1485.58 L758.792 1485.58 L758.792 1481.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M792.171 1481.64 L808.491 1481.64 L808.491 1485.58 L786.546 1485.58 L786.546 1481.64 Q789.208 1478.89 793.792 1474.26 Q798.398 1469.61 799.579 1468.27 Q801.824 1465.74 802.704 1464.01 Q803.606 1462.25 803.606 1460.56 Q803.606 1457.8 801.662 1456.07 Q799.741 1454.33 796.639 1454.33 Q794.44 1454.33 791.986 1455.09 Q789.556 1455.86 786.778 1457.41 L786.778 1452.69 Q789.602 1451.55 792.056 1450.97 Q794.509 1450.39 796.546 1450.39 Q801.917 1450.39 805.111 1453.08 Q808.305 1455.77 808.305 1460.26 Q808.305 1462.39 807.495 1464.31 Q806.708 1466.2 804.602 1468.8 Q804.023 1469.47 800.921 1472.69 Q797.819 1475.88 792.171 1481.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M995.769 1468.75 L1025.44 1468.75 L1025.44 1472.69 L995.769 1472.69 L995.769 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1036.35 1481.64 L1043.99 1481.64 L1043.99 1455.28 L1035.68 1456.95 L1035.68 1452.69 L1043.94 1451.02 L1048.62 1451.02 L1048.62 1481.64 L1056.25 1481.64 L1056.25 1485.58 L1036.35 1485.58 L1036.35 1481.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1075.7 1454.1 Q1072.09 1454.1 1070.26 1457.66 Q1068.45 1461.2 1068.45 1468.33 Q1068.45 1475.44 1070.26 1479.01 Q1072.09 1482.55 1075.7 1482.55 Q1079.33 1482.55 1081.14 1479.01 Q1082.97 1475.44 1082.97 1468.33 Q1082.97 1461.2 1081.14 1457.66 Q1079.33 1454.1 1075.7 1454.1 M1075.7 1450.39 Q1081.51 1450.39 1084.57 1455 Q1087.64 1459.58 1087.64 1468.33 Q1087.64 1477.06 1084.57 1481.67 Q1081.51 1486.25 1075.7 1486.25 Q1069.89 1486.25 1066.81 1481.67 Q1063.75 1477.06 1063.75 1468.33 Q1063.75 1459.58 1066.81 1455 Q1069.89 1450.39 1075.7 1450.39 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1289.25 1468.75 L1318.93 1468.75 L1318.93 1472.69 L1289.25 1472.69 L1289.25 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1339.02 1469.17 Q1335.69 1469.17 1333.76 1470.95 Q1331.87 1472.73 1331.87 1475.86 Q1331.87 1478.98 1333.76 1480.77 Q1335.69 1482.55 1339.02 1482.55 Q1342.35 1482.55 1344.27 1480.77 Q1346.2 1478.96 1346.2 1475.86 Q1346.2 1472.73 1344.27 1470.95 Q1342.38 1469.17 1339.02 1469.17 M1334.34 1467.18 Q1331.33 1466.44 1329.64 1464.38 Q1327.98 1462.32 1327.98 1459.35 Q1327.98 1455.21 1330.92 1452.8 Q1333.88 1450.39 1339.02 1450.39 Q1344.18 1450.39 1347.12 1452.8 Q1350.06 1455.21 1350.06 1459.35 Q1350.06 1462.32 1348.37 1464.38 Q1346.7 1466.44 1343.72 1467.18 Q1347.1 1467.96 1348.97 1470.26 Q1350.87 1472.55 1350.87 1475.86 Q1350.87 1480.88 1347.79 1483.57 Q1344.74 1486.25 1339.02 1486.25 Q1333.3 1486.25 1330.22 1483.57 Q1327.17 1480.88 1327.17 1475.86 Q1327.17 1472.55 1329.07 1470.26 Q1330.96 1467.96 1334.34 1467.18 M1332.63 1459.79 Q1332.63 1462.48 1334.3 1463.98 Q1335.99 1465.49 1339.02 1465.49 Q1342.03 1465.49 1343.72 1463.98 Q1345.43 1462.48 1345.43 1459.79 Q1345.43 1457.11 1343.72 1455.6 Q1342.03 1454.1 1339.02 1454.1 Q1335.99 1454.1 1334.3 1455.6 Q1332.63 1457.11 1332.63 1459.79 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1567.48 1468.75 L1597.15 1468.75 L1597.15 1472.69 L1567.48 1472.69 L1567.48 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1617.82 1466.44 Q1614.68 1466.44 1612.82 1468.59 Q1611 1470.74 1611 1474.49 Q1611 1478.22 1612.82 1480.39 Q1614.68 1482.55 1617.82 1482.55 Q1620.97 1482.55 1622.8 1480.39 Q1624.65 1478.22 1624.65 1474.49 Q1624.65 1470.74 1622.8 1468.59 Q1620.97 1466.44 1617.82 1466.44 M1627.11 1451.78 L1627.11 1456.04 Q1625.35 1455.21 1623.54 1454.77 Q1621.76 1454.33 1620 1454.33 Q1615.37 1454.33 1612.92 1457.45 Q1610.49 1460.58 1610.14 1466.9 Q1611.51 1464.89 1613.57 1463.82 Q1615.63 1462.73 1618.1 1462.73 Q1623.31 1462.73 1626.32 1465.9 Q1629.35 1469.05 1629.35 1474.49 Q1629.35 1479.82 1626.2 1483.03 Q1623.06 1486.25 1617.82 1486.25 Q1611.83 1486.25 1608.66 1481.67 Q1605.49 1477.06 1605.49 1468.33 Q1605.49 1460.14 1609.38 1455.28 Q1613.26 1450.39 1619.82 1450.39 Q1621.57 1450.39 1623.36 1450.74 Q1625.16 1451.09 1627.11 1451.78 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1845.67 1468.75 L1875.35 1468.75 L1875.35 1472.69 L1845.67 1472.69 L1845.67 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1898.29 1455.09 L1886.48 1473.54 L1898.29 1473.54 L1898.29 1455.09 M1897.06 1451.02 L1902.94 1451.02 L1902.94 1473.54 L1907.87 1473.54 L1907.87 1477.43 L1902.94 1477.43 L1902.94 1485.58 L1898.29 1485.58 L1898.29 1477.43 L1882.68 1477.43 L1882.68 1472.92 L1897.06 1451.02 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M2125.07 1468.75 L2154.74 1468.75 L2154.74 1472.69 L2125.07 1472.69 L2125.07 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M2168.86 1481.64 L2185.18 1481.64 L2185.18 1485.58 L2163.24 1485.58 L2163.24 1481.64 Q2165.9 1478.89 2170.48 1474.26 Q2175.09 1469.61 2176.27 1468.27 Q2178.52 1465.74 2179.39 1464.01 Q2180.3 1462.25 2180.3 1460.56 Q2180.3 1457.8 2178.35 1456.07 Q2176.43 1454.33 2173.33 1454.33 Q2171.13 1454.33 2168.68 1455.09 Q2166.25 1455.86 2163.47 1457.41 L2163.47 1452.69 Q2166.29 1451.55 2168.75 1450.97 Q2171.2 1450.39 2173.24 1450.39 Q2178.61 1450.39 2181.8 1453.08 Q2185 1455.77 2185 1460.26 Q2185 1462.39 2184.19 1464.31 Q2183.4 1466.2 2181.29 1468.8 Q2180.71 1469.47 2177.61 1472.69 Q2174.51 1475.88 2168.86 1481.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1175.45 1547.58 L1192.6 1547.58 L1192.6 1552.8 L1175.45 1552.8 L1175.45 1547.58 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1201.93 1518.52 L1207.79 1518.52 L1207.79 1568.04 L1201.93 1568.04 L1201.93 1518.52 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1233.85 1536.5 Q1229.14 1536.5 1226.41 1540.19 Q1223.67 1543.85 1223.67 1550.25 Q1223.67 1556.65 1226.37 1560.34 Q1229.11 1564 1233.85 1564 Q1238.53 1564 1241.27 1560.31 Q1244.01 1556.62 1244.01 1550.25 Q1244.01 1543.92 1241.27 1540.23 Q1238.53 1536.5 1233.85 1536.5 M1233.85 1531.54 Q1241.49 1531.54 1245.85 1536.5 Q1250.21 1541.47 1250.21 1550.25 Q1250.21 1559 1245.85 1564 Q1241.49 1568.97 1233.85 1568.97 Q1226.18 1568.97 1221.82 1564 Q1217.49 1559 1217.49 1550.25 Q1217.49 1541.47 1221.82 1536.5 Q1226.18 1531.54 1233.85 1531.54 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1283.38 1549.81 Q1283.38 1543.44 1280.74 1539.94 Q1278.13 1536.44 1273.38 1536.44 Q1268.67 1536.44 1266.03 1539.94 Q1263.42 1543.44 1263.42 1549.81 Q1263.42 1556.14 1266.03 1559.64 Q1268.67 1563.14 1273.38 1563.14 Q1278.13 1563.14 1280.74 1559.64 Q1283.38 1556.14 1283.38 1549.81 M1289.23 1563.62 Q1289.23 1572.72 1285.19 1577.15 Q1281.15 1581.6 1272.81 1581.6 Q1269.72 1581.6 1266.99 1581.13 Q1264.25 1580.68 1261.67 1579.72 L1261.67 1574.03 Q1264.25 1575.43 1266.76 1576.1 Q1269.28 1576.76 1271.89 1576.76 Q1277.65 1576.76 1280.51 1573.74 Q1283.38 1570.75 1283.38 1564.67 L1283.38 1561.77 Q1281.56 1564.92 1278.73 1566.48 Q1275.9 1568.04 1271.95 1568.04 Q1265.4 1568.04 1261.39 1563.05 Q1257.37 1558.05 1257.37 1549.81 Q1257.37 1541.53 1261.39 1536.53 Q1265.4 1531.54 1271.95 1531.54 Q1275.9 1531.54 1278.73 1533.1 Q1281.56 1534.66 1283.38 1537.81 L1283.38 1532.4 L1289.23 1532.4 L1289.23 1563.62 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1303.24 1562.63 L1313.74 1562.63 L1313.74 1526.38 L1302.32 1528.67 L1302.32 1522.82 L1313.68 1520.52 L1320.11 1520.52 L1320.11 1562.63 L1330.61 1562.63 L1330.61 1568.04 L1303.24 1568.04 L1303.24 1562.63 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1357.35 1524.76 Q1352.38 1524.76 1349.87 1529.66 Q1347.39 1534.53 1347.39 1544.33 Q1347.39 1554.1 1349.87 1559 Q1352.38 1563.87 1357.35 1563.87 Q1362.35 1563.87 1364.83 1559 Q1367.34 1554.1 1367.34 1544.33 Q1367.34 1534.53 1364.83 1529.66 Q1362.35 1524.76 1357.35 1524.76 M1357.35 1519.66 Q1365.34 1519.66 1369.54 1526 Q1373.77 1532.3 1373.77 1544.33 Q1373.77 1556.33 1369.54 1562.66 Q1365.34 1568.97 1357.35 1568.97 Q1349.36 1568.97 1345.13 1562.66 Q1340.92 1556.33 1340.92 1544.33 Q1340.92 1532.3 1345.13 1526 Q1349.36 1519.66 1357.35 1519.66 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1398.31 1518.58 Q1394.05 1525.9 1391.98 1533.06 Q1389.91 1540.23 1389.91 1547.58 Q1389.91 1554.93 1391.98 1562.16 Q1394.08 1569.35 1398.31 1576.64 L1393.22 1576.64 Q1388.44 1569.16 1386.06 1561.93 Q1383.7 1554.71 1383.7 1547.58 Q1383.7 1540.48 1386.06 1533.29 Q1388.41 1526.09 1393.22 1518.58 L1398.31 1518.58 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1439.31 1546.53 L1439.31 1568.04 L1433.45 1568.04 L1433.45 1546.72 Q1433.45 1541.66 1431.48 1539.14 Q1429.5 1536.63 1425.56 1536.63 Q1420.81 1536.63 1418.08 1539.65 Q1415.34 1542.68 1415.34 1547.9 L1415.34 1568.04 L1409.45 1568.04 L1409.45 1518.52 L1415.34 1518.52 L1415.34 1537.93 Q1417.44 1534.72 1420.27 1533.13 Q1423.14 1531.54 1426.86 1531.54 Q1433 1531.54 1436.16 1535.36 Q1439.31 1539.14 1439.31 1546.53 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M1450.06 1518.58 L1455.16 1518.58 Q1459.93 1526.09 1462.29 1533.29 Q1464.67 1540.48 1464.67 1547.58 Q1464.67 1554.71 1462.29 1561.93 Q1459.93 1569.16 1455.16 1576.64 L1450.06 1576.64 Q1454.3 1569.35 1456.37 1562.16 Q1458.47 1554.93 1458.47 1547.58 Q1458.47 1540.23 1456.37 1533.06 Q1454.3 1525.9 1450.06 1518.58 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,1423.18 287.366,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,1367.63 306.264,1367.63 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,1046.25 306.264,1046.25 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,724.881 306.264,724.881 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,403.508 306.264,403.508 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,82.1342 306.264,82.1342 \"/>\n",
+       "<path clip-path=\"url(#clip240)\" d=\"M114.26 1368.08 L143.936 1368.08 L143.936 1372.01 L114.26 1372.01 L114.26 1368.08 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M154.839 1380.97 L162.477 1380.97 L162.477 1354.61 L154.167 1356.27 L154.167 1352.02 L162.431 1350.35 L167.107 1350.35 L167.107 1380.97 L174.746 1380.97 L174.746 1384.91 L154.839 1384.91 L154.839 1380.97 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M194.19 1353.43 Q190.579 1353.43 188.75 1356.99 Q186.945 1360.53 186.945 1367.66 Q186.945 1374.77 188.75 1378.33 Q190.579 1381.88 194.19 1381.88 Q197.825 1381.88 199.63 1378.33 Q201.459 1374.77 201.459 1367.66 Q201.459 1360.53 199.63 1356.99 Q197.825 1353.43 194.19 1353.43 M194.19 1349.72 Q200 1349.72 203.056 1354.33 Q206.135 1358.91 206.135 1367.66 Q206.135 1376.39 203.056 1381 Q200 1385.58 194.19 1385.58 Q188.38 1385.58 185.301 1381 Q182.246 1376.39 182.246 1367.66 Q182.246 1358.91 185.301 1354.33 Q188.38 1349.72 194.19 1349.72 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M214.352 1379.03 L219.236 1379.03 L219.236 1384.91 L214.352 1384.91 L214.352 1379.03 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M239.422 1353.43 Q235.81 1353.43 233.982 1356.99 Q232.176 1360.53 232.176 1367.66 Q232.176 1374.77 233.982 1378.33 Q235.81 1381.88 239.422 1381.88 Q243.056 1381.88 244.861 1378.33 Q246.69 1374.77 246.69 1367.66 Q246.69 1360.53 244.861 1356.99 Q243.056 1353.43 239.422 1353.43 M239.422 1349.72 Q245.232 1349.72 248.287 1354.33 Q251.366 1358.91 251.366 1367.66 Q251.366 1376.39 248.287 1381 Q245.232 1385.58 239.422 1385.58 Q233.611 1385.58 230.533 1381 Q227.477 1376.39 227.477 1367.66 Q227.477 1358.91 230.533 1354.33 Q233.611 1349.72 239.422 1349.72 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M145.417 1046.71 L175.093 1046.71 L175.093 1050.64 L145.417 1050.64 L145.417 1046.71 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M184.005 1028.97 L206.227 1028.97 L206.227 1030.97 L193.681 1063.53 L188.797 1063.53 L200.602 1032.91 L184.005 1032.91 L184.005 1028.97 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M215.348 1057.66 L220.232 1057.66 L220.232 1063.53 L215.348 1063.53 L215.348 1057.66 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M230.463 1028.97 L248.82 1028.97 L248.82 1032.91 L234.746 1032.91 L234.746 1041.38 Q235.764 1041.03 236.783 1040.87 Q237.801 1040.69 238.82 1040.69 Q244.607 1040.69 247.986 1043.86 Q251.366 1047.03 251.366 1052.45 Q251.366 1058.03 247.894 1061.13 Q244.421 1064.21 238.102 1064.21 Q235.926 1064.21 233.658 1063.84 Q231.412 1063.47 229.005 1062.72 L229.005 1058.03 Q231.088 1059.16 233.31 1059.72 Q235.533 1060.27 238.009 1060.27 Q242.014 1060.27 244.352 1058.16 Q246.69 1056.06 246.69 1052.45 Q246.69 1048.84 244.352 1046.73 Q242.014 1044.62 238.009 1044.62 Q236.135 1044.62 234.26 1045.04 Q232.408 1045.46 230.463 1046.34 L230.463 1028.97 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M144.422 725.333 L174.098 725.333 L174.098 729.268 L144.422 729.268 L144.422 725.333 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M184.237 707.601 L202.593 707.601 L202.593 711.536 L188.519 711.536 L188.519 720.009 Q189.538 719.661 190.556 719.499 Q191.575 719.314 192.593 719.314 Q198.38 719.314 201.76 722.485 Q205.139 725.657 205.139 731.073 Q205.139 736.652 201.667 739.754 Q198.195 742.833 191.875 742.833 Q189.7 742.833 187.431 742.462 Q185.186 742.092 182.778 741.351 L182.778 736.652 Q184.862 737.786 187.084 738.342 Q189.306 738.897 191.783 738.897 Q195.787 738.897 198.125 736.791 Q200.463 734.684 200.463 731.073 Q200.463 727.462 198.125 725.356 Q195.787 723.249 191.783 723.249 Q189.908 723.249 188.033 723.666 Q186.181 724.083 184.237 724.962 L184.237 707.601 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M214.352 736.282 L219.236 736.282 L219.236 742.161 L214.352 742.161 L214.352 736.282 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M239.422 710.68 Q235.81 710.68 233.982 714.245 Q232.176 717.786 232.176 724.916 Q232.176 732.022 233.982 735.587 Q235.81 739.129 239.422 739.129 Q243.056 739.129 244.861 735.587 Q246.69 732.022 246.69 724.916 Q246.69 717.786 244.861 714.245 Q243.056 710.68 239.422 710.68 M239.422 706.976 Q245.232 706.976 248.287 711.583 Q251.366 716.166 251.366 724.916 Q251.366 733.643 248.287 738.249 Q245.232 742.833 239.422 742.833 Q233.611 742.833 230.533 738.249 Q227.477 733.643 227.477 724.916 Q227.477 716.166 230.533 711.583 Q233.611 706.976 239.422 706.976 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M145.417 403.959 L175.093 403.959 L175.093 407.894 L145.417 407.894 L145.417 403.959 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M189.213 416.853 L205.533 416.853 L205.533 420.788 L183.588 420.788 L183.588 416.853 Q186.251 414.098 190.834 409.468 Q195.44 404.816 196.621 403.473 Q198.866 400.95 199.746 399.214 Q200.649 397.455 200.649 395.765 Q200.649 393.01 198.704 391.274 Q196.783 389.538 193.681 389.538 Q191.482 389.538 189.028 390.302 Q186.598 391.066 183.82 392.617 L183.82 387.894 Q186.644 386.76 189.098 386.181 Q191.551 385.603 193.588 385.603 Q198.959 385.603 202.153 388.288 Q205.348 390.973 205.348 395.464 Q205.348 397.593 204.537 399.515 Q203.75 401.413 201.644 404.005 Q201.065 404.677 197.963 407.894 Q194.862 411.089 189.213 416.853 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M215.348 414.908 L220.232 414.908 L220.232 420.788 L215.348 420.788 L215.348 414.908 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M230.463 386.228 L248.82 386.228 L248.82 390.163 L234.746 390.163 L234.746 398.635 Q235.764 398.288 236.783 398.126 Q237.801 397.941 238.82 397.941 Q244.607 397.941 247.986 401.112 Q251.366 404.283 251.366 409.7 Q251.366 415.278 247.894 418.38 Q244.421 421.459 238.102 421.459 Q235.926 421.459 233.658 421.089 Q231.412 420.718 229.005 419.978 L229.005 415.278 Q231.088 416.413 233.31 416.968 Q235.533 417.524 238.009 417.524 Q242.014 417.524 244.352 415.417 Q246.69 413.311 246.69 409.7 Q246.69 406.089 244.352 403.982 Q242.014 401.876 238.009 401.876 Q236.135 401.876 234.26 402.292 Q232.408 402.709 230.463 403.589 L230.463 386.228 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M194.19 67.9329 Q190.579 67.9329 188.75 71.4977 Q186.945 75.0393 186.945 82.1689 Q186.945 89.2753 188.75 92.8401 Q190.579 96.3818 194.19 96.3818 Q197.825 96.3818 199.63 92.8401 Q201.459 89.2753 201.459 82.1689 Q201.459 75.0393 199.63 71.4977 Q197.825 67.9329 194.19 67.9329 M194.19 64.2292 Q200 64.2292 203.056 68.8356 Q206.135 73.4189 206.135 82.1689 Q206.135 90.8957 203.056 95.5022 Q200 100.085 194.19 100.085 Q188.38 100.085 185.301 95.5022 Q182.246 90.8957 182.246 82.1689 Q182.246 73.4189 185.301 68.8356 Q188.38 64.2292 194.19 64.2292 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M214.352 93.5346 L219.236 93.5346 L219.236 99.4142 L214.352 99.4142 L214.352 93.5346 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M239.422 67.9329 Q235.81 67.9329 233.982 71.4977 Q232.176 75.0393 232.176 82.1689 Q232.176 89.2753 233.982 92.8401 Q235.81 96.3818 239.422 96.3818 Q243.056 96.3818 244.861 92.8401 Q246.69 89.2753 246.69 82.1689 Q246.69 75.0393 244.861 71.4977 Q243.056 67.9329 239.422 67.9329 M239.422 64.2292 Q245.232 64.2292 248.287 68.8356 Q251.366 73.4189 251.366 82.1689 Q251.366 90.8957 248.287 95.5022 Q245.232 100.085 239.422 100.085 Q233.611 100.085 230.533 95.5022 Q227.477 90.8957 227.477 82.1689 Q227.477 73.4189 230.533 68.8356 Q233.611 64.2292 239.422 64.2292 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M14.479 941.127 L14.479 935.27 L64.0042 935.27 L64.0042 941.127 L14.479 941.127 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M32.4621 909.203 Q32.4621 913.913 36.1542 916.651 Q39.8145 919.388 46.212 919.388 Q52.6095 919.388 56.3017 916.682 Q59.9619 913.945 59.9619 909.203 Q59.9619 904.524 56.2698 901.787 Q52.5777 899.049 46.212 899.049 Q39.8781 899.049 36.186 901.787 Q32.4621 904.524 32.4621 909.203 M27.4968 909.203 Q27.4968 901.564 32.4621 897.203 Q37.4273 892.843 46.212 892.843 Q54.9649 892.843 59.9619 897.203 Q64.9272 901.564 64.9272 909.203 Q64.9272 916.873 59.9619 921.234 Q54.9649 925.563 46.212 925.563 Q37.4273 925.563 32.4621 921.234 Q27.4968 916.873 27.4968 909.203 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M45.7664 859.677 Q39.4007 859.677 35.8996 862.319 Q32.3984 864.929 32.3984 869.672 Q32.3984 874.382 35.8996 877.024 Q39.4007 879.634 45.7664 879.634 Q52.1003 879.634 55.6014 877.024 Q59.1026 874.382 59.1026 869.672 Q59.1026 864.929 55.6014 862.319 Q52.1003 859.677 45.7664 859.677 M59.58 853.821 Q68.683 853.821 73.1071 857.863 Q77.5631 861.905 77.5631 870.245 Q77.5631 873.332 77.0857 876.069 Q76.6401 878.806 75.6852 881.385 L69.9879 881.385 Q71.3884 878.806 72.0568 876.292 Q72.7252 873.777 72.7252 871.168 Q72.7252 865.407 69.7015 862.542 Q66.7096 859.677 60.6303 859.677 L57.7339 859.677 Q60.885 861.492 62.4446 864.324 Q64.0042 867.157 64.0042 871.104 Q64.0042 877.661 59.0071 881.671 Q54.01 885.681 45.7664 885.681 Q37.491 885.681 32.4939 881.671 Q27.4968 877.661 27.4968 871.104 Q27.4968 867.157 29.0564 864.324 Q30.616 861.492 33.7671 859.677 L28.3562 859.677 L28.3562 853.821 L59.58 853.821 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M74.8259 814.672 L79.3773 814.672 L79.3773 848.537 L74.8259 848.537 L74.8259 814.672 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M58.5933 807.224 L58.5933 796.721 L22.3406 796.721 L24.6323 808.147 L18.7758 808.147 L16.4842 796.784 L16.4842 790.355 L58.5933 790.355 L58.5933 779.851 L64.0042 779.851 L64.0042 807.224 L58.5933 807.224 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M20.7174 753.116 Q20.7174 758.081 25.6189 760.595 Q30.4887 763.078 40.2919 763.078 Q50.0633 763.078 54.9649 760.595 Q59.8346 758.081 59.8346 753.116 Q59.8346 748.118 54.9649 745.636 Q50.0633 743.121 40.2919 743.121 Q30.4887 743.121 25.6189 745.636 Q20.7174 748.118 20.7174 753.116 M15.6248 753.116 Q15.6248 745.127 21.9587 740.925 Q28.2607 736.692 40.2919 736.692 Q52.2913 736.692 58.6251 740.925 Q64.9272 745.127 64.9272 753.116 Q64.9272 761.104 58.6251 765.338 Q52.2913 769.539 40.2919 769.539 Q28.2607 769.539 21.9587 765.338 Q15.6248 761.104 15.6248 753.116 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M14.5426 712.152 Q21.8632 716.417 29.0246 718.486 Q36.186 720.555 43.5384 720.555 Q50.8908 720.555 58.1159 718.486 Q65.3091 716.385 72.5979 712.152 L72.5979 717.245 Q65.1182 722.019 57.8931 724.406 Q50.668 726.761 43.5384 726.761 Q36.4406 726.761 29.2474 724.406 Q22.0542 722.051 14.5426 717.245 L14.5426 712.152 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M44.7161 670.298 L47.5806 670.298 L47.5806 697.225 Q53.6281 696.843 56.8109 693.596 Q59.9619 690.318 59.9619 684.493 Q59.9619 681.119 59.1344 677.968 Q58.3069 674.785 56.6518 671.666 L62.1899 671.666 Q63.5267 674.817 64.227 678.127 Q64.9272 681.438 64.9272 684.843 Q64.9272 693.373 59.9619 698.37 Q54.9967 703.336 46.5303 703.336 Q37.7774 703.336 32.6531 698.625 Q27.4968 693.883 27.4968 685.862 Q27.4968 678.669 32.1438 674.499 Q36.7589 670.298 44.7161 670.298 M42.9973 676.154 Q38.1912 676.218 35.3266 678.86 Q32.4621 681.469 32.4621 685.798 Q32.4621 690.7 35.2312 693.66 Q38.0002 696.588 43.0292 697.034 L42.9973 676.154 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M33.8307 640.029 Q33.2578 641.015 33.0032 642.193 Q32.7167 643.339 32.7167 644.739 Q32.7167 649.705 35.9632 652.378 Q39.1779 655.02 45.2253 655.02 L64.0042 655.02 L64.0042 660.908 L28.3562 660.908 L28.3562 655.02 L33.8944 655.02 Q30.6479 653.174 29.0883 650.214 Q27.4968 647.254 27.4968 643.021 Q27.4968 642.416 27.5923 641.684 Q27.656 640.952 27.8151 640.061 L33.8307 640.029 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M33.8307 614.375 Q33.2578 615.362 33.0032 616.539 Q32.7167 617.685 32.7167 619.086 Q32.7167 624.051 35.9632 626.724 Q39.1779 629.366 45.2253 629.366 L64.0042 629.366 L64.0042 635.254 L28.3562 635.254 L28.3562 629.366 L33.8944 629.366 Q30.6479 627.52 29.0883 624.56 Q27.4968 621.6 27.4968 617.367 Q27.4968 616.762 27.5923 616.03 Q27.656 615.298 27.8151 614.407 L33.8307 614.375 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M32.4621 595.851 Q32.4621 600.561 36.1542 603.299 Q39.8145 606.036 46.212 606.036 Q52.6095 606.036 56.3017 603.33 Q59.9619 600.593 59.9619 595.851 Q59.9619 591.172 56.2698 588.435 Q52.5777 585.697 46.212 585.697 Q39.8781 585.697 36.186 588.435 Q32.4621 591.172 32.4621 595.851 M27.4968 595.851 Q27.4968 588.212 32.4621 583.851 Q37.4273 579.491 46.212 579.491 Q54.9649 579.491 59.9619 583.851 Q64.9272 588.212 64.9272 595.851 Q64.9272 603.521 59.9619 607.882 Q54.9649 612.211 46.212 612.211 Q37.4273 612.211 32.4621 607.882 Q27.4968 603.521 27.4968 595.851 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M33.8307 549.126 Q33.2578 550.113 33.0032 551.291 Q32.7167 552.437 32.7167 553.837 Q32.7167 558.802 35.9632 561.476 Q39.1779 564.118 45.2253 564.118 L64.0042 564.118 L64.0042 570.006 L28.3562 570.006 L28.3562 564.118 L33.8944 564.118 Q30.6479 562.272 29.0883 559.312 Q27.4968 556.352 27.4968 552.118 Q27.4968 551.514 27.5923 550.782 Q27.656 550.049 27.8151 549.158 L33.8307 549.126 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M14.5426 543.907 L14.5426 538.814 Q22.0542 534.04 29.2474 531.684 Q36.4406 529.297 43.5384 529.297 Q50.668 529.297 57.8931 531.684 Q65.1182 534.04 72.5979 538.814 L72.5979 543.907 Q65.3091 539.673 58.1159 537.605 Q50.8908 535.504 43.5384 535.504 Q36.186 535.504 29.0246 537.605 Q21.8632 539.673 14.5426 543.907 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><polyline clip-path=\"url(#clip242)\" style=\"stroke:#009af9; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"2294.3,86.1857 2155.12,216.38 2015.95,345.097 1876.77,473.663 1737.59,602.214 1598.42,730.767 1459.24,859.032 1320.06,1042.01 1180.88,869.89 1041.71,869.89 902.529,869.89 763.352,480.233 624.175,357.623 484.998,279.031 345.82,96.7284 \"/>\n",
+       "<polyline clip-path=\"url(#clip242)\" style=\"stroke:#e26f46; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"2294.3,277.899 2155.12,534.998 2015.95,792.097 1876.77,1049.21 1737.59,1305.7 1598.42,1384.24 1459.24,1250.57 1320.06,1108.94 1180.88,920.54 1041.71,869.89 902.529,869.89 763.352,525.441 624.175,411.254 484.998,279.031 345.82,144.731 \"/>\n",
+       "<path clip-path=\"url(#clip240)\" d=\"M356.212 1377.32 L1003.03 1377.32 L1003.03 1221.8 L356.212 1221.8  Z\" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"356.212,1377.32 1003.03,1377.32 1003.03,1221.8 356.212,1221.8 356.212,1377.32 \"/>\n",
+       "<polyline clip-path=\"url(#clip240)\" style=\"stroke:#009af9; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"379.161,1273.64 516.854,1273.64 \"/>\n",
+       "<path clip-path=\"url(#clip240)\" d=\"M544.478 1260.2 L544.478 1287.07 L550.126 1287.07 Q557.279 1287.07 560.589 1283.83 Q563.923 1280.59 563.923 1273.6 Q563.923 1266.66 560.589 1263.44 Q557.279 1260.2 550.126 1260.2 L544.478 1260.2 M539.802 1256.36 L549.409 1256.36 Q559.455 1256.36 564.154 1260.55 Q568.853 1264.71 568.853 1273.6 Q568.853 1282.54 564.131 1286.73 Q559.409 1290.92 549.409 1290.92 L539.802 1290.92 L539.802 1256.36 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M598.298 1276.89 L598.298 1278.97 L578.714 1278.97 Q578.992 1283.37 581.353 1285.68 Q583.737 1287.98 587.973 1287.98 Q590.427 1287.98 592.719 1287.37 Q595.034 1286.77 597.302 1285.57 L597.302 1289.6 Q595.01 1290.57 592.603 1291.08 Q590.196 1291.59 587.719 1291.59 Q581.515 1291.59 577.881 1287.98 Q574.27 1284.36 574.27 1278.21 Q574.27 1271.84 577.696 1268.11 Q581.145 1264.36 586.978 1264.36 Q592.21 1264.36 595.242 1267.74 Q598.298 1271.1 598.298 1276.89 M594.038 1275.64 Q593.992 1272.14 592.071 1270.06 Q590.173 1267.98 587.024 1267.98 Q583.46 1267.98 581.307 1269.99 Q579.177 1272 578.853 1275.66 L594.038 1275.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M620.311 1268.97 Q619.594 1268.55 618.737 1268.37 Q617.904 1268.16 616.885 1268.16 Q613.274 1268.16 611.33 1270.52 Q609.409 1272.86 609.409 1277.26 L609.409 1290.92 L605.126 1290.92 L605.126 1264.99 L609.409 1264.99 L609.409 1269.02 Q610.751 1266.66 612.904 1265.52 Q615.057 1264.36 618.135 1264.36 Q618.575 1264.36 619.108 1264.43 Q619.64 1264.48 620.288 1264.6 L620.311 1268.97 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M624.779 1264.99 L629.038 1264.99 L629.038 1290.92 L624.779 1290.92 L624.779 1264.99 M624.779 1254.9 L629.038 1254.9 L629.038 1260.29 L624.779 1260.29 L624.779 1254.9 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M634.895 1264.99 L639.408 1264.99 L647.51 1286.75 L655.612 1264.99 L660.126 1264.99 L650.404 1290.92 L644.617 1290.92 L634.895 1264.99 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M677.788 1277.88 Q672.626 1277.88 670.635 1279.06 Q668.644 1280.24 668.644 1283.09 Q668.644 1285.36 670.126 1286.7 Q671.63 1288.02 674.2 1288.02 Q677.742 1288.02 679.871 1285.52 Q682.024 1283 682.024 1278.83 L682.024 1277.88 L677.788 1277.88 M686.283 1276.12 L686.283 1290.92 L682.024 1290.92 L682.024 1286.98 Q680.566 1289.34 678.39 1290.48 Q676.214 1291.59 673.066 1291.59 Q669.084 1291.59 666.723 1289.36 Q664.385 1287.12 664.385 1283.37 Q664.385 1278.99 667.302 1276.77 Q670.242 1274.55 676.052 1274.55 L682.024 1274.55 L682.024 1274.13 Q682.024 1271.19 680.079 1269.6 Q678.158 1267.98 674.663 1267.98 Q672.441 1267.98 670.334 1268.51 Q668.228 1269.04 666.283 1270.11 L666.283 1266.17 Q668.621 1265.27 670.82 1264.83 Q673.019 1264.36 675.103 1264.36 Q680.728 1264.36 683.505 1267.28 Q686.283 1270.2 686.283 1276.12 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M712.116 1268.92 L712.116 1254.9 L716.376 1254.9 L716.376 1290.92 L712.116 1290.92 L712.116 1287.03 Q710.774 1289.34 708.714 1290.48 Q706.677 1291.59 703.806 1291.59 Q699.107 1291.59 696.144 1287.84 Q693.204 1284.09 693.204 1277.98 Q693.204 1271.86 696.144 1268.11 Q699.107 1264.36 703.806 1264.36 Q706.677 1264.36 708.714 1265.5 Q710.774 1266.61 712.116 1268.92 M697.603 1277.98 Q697.603 1282.67 699.524 1285.36 Q701.468 1288.02 704.848 1288.02 Q708.227 1288.02 710.172 1285.36 Q712.116 1282.67 712.116 1277.98 Q712.116 1273.28 710.172 1270.61 Q708.227 1267.93 704.848 1267.93 Q701.468 1267.93 699.524 1270.61 Q697.603 1273.28 697.603 1277.98 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M736.931 1277.88 Q731.769 1277.88 729.778 1279.06 Q727.788 1280.24 727.788 1283.09 Q727.788 1285.36 729.269 1286.7 Q730.774 1288.02 733.343 1288.02 Q736.885 1288.02 739.014 1285.52 Q741.167 1283 741.167 1278.83 L741.167 1277.88 L736.931 1277.88 M745.426 1276.12 L745.426 1290.92 L741.167 1290.92 L741.167 1286.98 Q739.709 1289.34 737.533 1290.48 Q735.357 1291.59 732.209 1291.59 Q728.227 1291.59 725.866 1289.36 Q723.528 1287.12 723.528 1283.37 Q723.528 1278.99 726.445 1276.77 Q729.385 1274.55 735.195 1274.55 L741.167 1274.55 L741.167 1274.13 Q741.167 1271.19 739.223 1269.6 Q737.301 1267.98 733.806 1267.98 Q731.584 1267.98 729.477 1268.51 Q727.371 1269.04 725.426 1270.11 L725.426 1266.17 Q727.764 1265.27 729.963 1264.83 Q732.163 1264.36 734.246 1264.36 Q739.871 1264.36 742.649 1267.28 Q745.426 1270.2 745.426 1276.12 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M786.329 1268.92 L786.329 1254.9 L790.588 1254.9 L790.588 1290.92 L786.329 1290.92 L786.329 1287.03 Q784.986 1289.34 782.926 1290.48 Q780.889 1291.59 778.019 1291.59 Q773.32 1291.59 770.357 1287.84 Q767.417 1284.09 767.417 1277.98 Q767.417 1271.86 770.357 1268.11 Q773.32 1264.36 778.019 1264.36 Q780.889 1264.36 782.926 1265.5 Q784.986 1266.61 786.329 1268.92 M771.815 1277.98 Q771.815 1282.67 773.736 1285.36 Q775.681 1288.02 779.06 1288.02 Q782.44 1288.02 784.384 1285.36 Q786.329 1282.67 786.329 1277.98 Q786.329 1273.28 784.384 1270.61 Q782.44 1267.93 779.06 1267.93 Q775.681 1267.93 773.736 1270.61 Q771.815 1273.28 771.815 1277.98 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M821.537 1276.89 L821.537 1278.97 L801.954 1278.97 Q802.232 1283.37 804.593 1285.68 Q806.977 1287.98 811.213 1287.98 Q813.667 1287.98 815.958 1287.37 Q818.273 1286.77 820.542 1285.57 L820.542 1289.6 Q818.25 1290.57 815.843 1291.08 Q813.435 1291.59 810.958 1291.59 Q804.755 1291.59 801.121 1287.98 Q797.509 1284.36 797.509 1278.21 Q797.509 1271.84 800.935 1268.11 Q804.384 1264.36 810.218 1264.36 Q815.449 1264.36 818.482 1267.74 Q821.537 1271.1 821.537 1276.89 M817.278 1275.64 Q817.232 1272.14 815.31 1270.06 Q813.412 1267.98 810.264 1267.98 Q806.699 1267.98 804.546 1269.99 Q802.417 1272 802.093 1275.66 L817.278 1275.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M843.551 1268.97 Q842.833 1268.55 841.977 1268.37 Q841.143 1268.16 840.125 1268.16 Q836.514 1268.16 834.569 1270.52 Q832.648 1272.86 832.648 1277.26 L832.648 1290.92 L828.366 1290.92 L828.366 1264.99 L832.648 1264.99 L832.648 1269.02 Q833.991 1266.66 836.143 1265.52 Q838.296 1264.36 841.375 1264.36 Q841.815 1264.36 842.347 1264.43 Q842.88 1264.48 843.528 1264.6 L843.551 1268.97 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M869.153 1276.89 L869.153 1278.97 L849.569 1278.97 Q849.847 1283.37 852.208 1285.68 Q854.592 1287.98 858.829 1287.98 Q861.282 1287.98 863.574 1287.37 Q865.889 1286.77 868.157 1285.57 L868.157 1289.6 Q865.866 1290.57 863.458 1291.08 Q861.051 1291.59 858.574 1291.59 Q852.37 1291.59 848.736 1287.98 Q845.125 1284.36 845.125 1278.21 Q845.125 1271.84 848.551 1268.11 Q852 1264.36 857.833 1264.36 Q863.065 1264.36 866.097 1267.74 Q869.153 1271.1 869.153 1276.89 M864.893 1275.64 Q864.847 1272.14 862.926 1270.06 Q861.028 1267.98 857.879 1267.98 Q854.315 1267.98 852.162 1269.99 Q850.032 1272 849.708 1275.66 L864.893 1275.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M894.801 1265.98 L894.801 1269.97 Q892.995 1268.97 891.166 1268.48 Q889.361 1267.98 887.509 1267.98 Q883.365 1267.98 881.074 1270.61 Q878.782 1273.23 878.782 1277.98 Q878.782 1282.72 881.074 1285.36 Q883.365 1287.98 887.509 1287.98 Q889.361 1287.98 891.166 1287.49 Q892.995 1286.98 894.801 1285.98 L894.801 1289.92 Q893.018 1290.75 891.097 1291.17 Q889.199 1291.59 887.046 1291.59 Q881.19 1291.59 877.74 1287.91 Q874.291 1284.23 874.291 1277.98 Q874.291 1271.63 877.764 1268 Q881.259 1264.36 887.324 1264.36 Q889.291 1264.36 891.166 1264.78 Q893.041 1265.17 894.801 1265.98 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M923.759 1275.27 L923.759 1290.92 L919.499 1290.92 L919.499 1275.41 Q919.499 1271.73 918.064 1269.9 Q916.629 1268.07 913.759 1268.07 Q910.31 1268.07 908.319 1270.27 Q906.328 1272.47 906.328 1276.26 L906.328 1290.92 L902.046 1290.92 L902.046 1254.9 L906.328 1254.9 L906.328 1269.02 Q907.856 1266.68 909.916 1265.52 Q912 1264.36 914.708 1264.36 Q919.175 1264.36 921.467 1267.14 Q923.759 1269.9 923.759 1275.27 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M944.036 1277.88 Q938.874 1277.88 936.884 1279.06 Q934.893 1280.24 934.893 1283.09 Q934.893 1285.36 936.374 1286.7 Q937.879 1288.02 940.448 1288.02 Q943.99 1288.02 946.12 1285.52 Q948.272 1283 948.272 1278.83 L948.272 1277.88 L944.036 1277.88 M952.532 1276.12 L952.532 1290.92 L948.272 1290.92 L948.272 1286.98 Q946.814 1289.34 944.638 1290.48 Q942.462 1291.59 939.314 1291.59 Q935.333 1291.59 932.972 1289.36 Q930.634 1287.12 930.634 1283.37 Q930.634 1278.99 933.55 1276.77 Q936.49 1274.55 942.3 1274.55 L948.272 1274.55 L948.272 1274.13 Q948.272 1271.19 946.328 1269.6 Q944.407 1267.98 940.911 1267.98 Q938.689 1267.98 936.583 1268.51 Q934.476 1269.04 932.532 1270.11 L932.532 1266.17 Q934.87 1265.27 937.069 1264.83 Q939.268 1264.36 941.351 1264.36 Q946.976 1264.36 949.754 1267.28 Q952.532 1270.2 952.532 1276.12 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><polyline clip-path=\"url(#clip240)\" style=\"stroke:#e26f46; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"379.161,1325.48 516.854,1325.48 \"/>\n",
+       "<path clip-path=\"url(#clip240)\" d=\"M544.478 1312.04 L544.478 1338.91 L550.126 1338.91 Q557.279 1338.91 560.589 1335.67 Q563.923 1332.43 563.923 1325.44 Q563.923 1318.5 560.589 1315.28 Q557.279 1312.04 550.126 1312.04 L544.478 1312.04 M539.802 1308.2 L549.409 1308.2 Q559.455 1308.2 564.154 1312.39 Q568.853 1316.55 568.853 1325.44 Q568.853 1334.38 564.131 1338.57 Q559.409 1342.76 549.409 1342.76 L539.802 1342.76 L539.802 1308.2 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M598.298 1328.73 L598.298 1330.81 L578.714 1330.81 Q578.992 1335.21 581.353 1337.52 Q583.737 1339.82 587.973 1339.82 Q590.427 1339.82 592.719 1339.21 Q595.034 1338.61 597.302 1337.41 L597.302 1341.44 Q595.01 1342.41 592.603 1342.92 Q590.196 1343.43 587.719 1343.43 Q581.515 1343.43 577.881 1339.82 Q574.27 1336.2 574.27 1330.05 Q574.27 1323.68 577.696 1319.95 Q581.145 1316.2 586.978 1316.2 Q592.21 1316.2 595.242 1319.58 Q598.298 1322.94 598.298 1328.73 M594.038 1327.48 Q593.992 1323.98 592.071 1321.9 Q590.173 1319.82 587.024 1319.82 Q583.46 1319.82 581.307 1321.83 Q579.177 1323.84 578.853 1327.5 L594.038 1327.48 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M620.311 1320.81 Q619.594 1320.39 618.737 1320.21 Q617.904 1320 616.885 1320 Q613.274 1320 611.33 1322.36 Q609.409 1324.7 609.409 1329.1 L609.409 1342.76 L605.126 1342.76 L605.126 1316.83 L609.409 1316.83 L609.409 1320.86 Q610.751 1318.5 612.904 1317.36 Q615.057 1316.2 618.135 1316.2 Q618.575 1316.2 619.108 1316.27 Q619.64 1316.32 620.288 1316.44 L620.311 1320.81 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M624.779 1316.83 L629.038 1316.83 L629.038 1342.76 L624.779 1342.76 L624.779 1316.83 M624.779 1306.74 L629.038 1306.74 L629.038 1312.13 L624.779 1312.13 L624.779 1306.74 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M634.895 1316.83 L639.408 1316.83 L647.51 1338.59 L655.612 1316.83 L660.126 1316.83 L650.404 1342.76 L644.617 1342.76 L634.895 1316.83 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M677.788 1329.72 Q672.626 1329.72 670.635 1330.9 Q668.644 1332.08 668.644 1334.93 Q668.644 1337.2 670.126 1338.54 Q671.63 1339.86 674.2 1339.86 Q677.742 1339.86 679.871 1337.36 Q682.024 1334.84 682.024 1330.67 L682.024 1329.72 L677.788 1329.72 M686.283 1327.96 L686.283 1342.76 L682.024 1342.76 L682.024 1338.82 Q680.566 1341.18 678.39 1342.32 Q676.214 1343.43 673.066 1343.43 Q669.084 1343.43 666.723 1341.2 Q664.385 1338.96 664.385 1335.21 Q664.385 1330.83 667.302 1328.61 Q670.242 1326.39 676.052 1326.39 L682.024 1326.39 L682.024 1325.97 Q682.024 1323.03 680.079 1321.44 Q678.158 1319.82 674.663 1319.82 Q672.441 1319.82 670.334 1320.35 Q668.228 1320.88 666.283 1321.95 L666.283 1318.01 Q668.621 1317.11 670.82 1316.67 Q673.019 1316.2 675.103 1316.2 Q680.728 1316.2 683.505 1319.12 Q686.283 1322.04 686.283 1327.96 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M712.116 1320.76 L712.116 1306.74 L716.376 1306.74 L716.376 1342.76 L712.116 1342.76 L712.116 1338.87 Q710.774 1341.18 708.714 1342.32 Q706.677 1343.43 703.806 1343.43 Q699.107 1343.43 696.144 1339.68 Q693.204 1335.93 693.204 1329.82 Q693.204 1323.7 696.144 1319.95 Q699.107 1316.2 703.806 1316.2 Q706.677 1316.2 708.714 1317.34 Q710.774 1318.45 712.116 1320.76 M697.603 1329.82 Q697.603 1334.51 699.524 1337.2 Q701.468 1339.86 704.848 1339.86 Q708.227 1339.86 710.172 1337.2 Q712.116 1334.51 712.116 1329.82 Q712.116 1325.12 710.172 1322.45 Q708.227 1319.77 704.848 1319.77 Q701.468 1319.77 699.524 1322.45 Q697.603 1325.12 697.603 1329.82 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M736.931 1329.72 Q731.769 1329.72 729.778 1330.9 Q727.788 1332.08 727.788 1334.93 Q727.788 1337.2 729.269 1338.54 Q730.774 1339.86 733.343 1339.86 Q736.885 1339.86 739.014 1337.36 Q741.167 1334.84 741.167 1330.67 L741.167 1329.72 L736.931 1329.72 M745.426 1327.96 L745.426 1342.76 L741.167 1342.76 L741.167 1338.82 Q739.709 1341.18 737.533 1342.32 Q735.357 1343.43 732.209 1343.43 Q728.227 1343.43 725.866 1341.2 Q723.528 1338.96 723.528 1335.21 Q723.528 1330.83 726.445 1328.61 Q729.385 1326.39 735.195 1326.39 L741.167 1326.39 L741.167 1325.97 Q741.167 1323.03 739.223 1321.44 Q737.301 1319.82 733.806 1319.82 Q731.584 1319.82 729.477 1320.35 Q727.371 1320.88 725.426 1321.95 L725.426 1318.01 Q727.764 1317.11 729.963 1316.67 Q732.163 1316.2 734.246 1316.2 Q739.871 1316.2 742.649 1319.12 Q745.426 1322.04 745.426 1327.96 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M785.797 1317.59 L785.797 1321.62 Q783.991 1320.7 782.047 1320.23 Q780.102 1319.77 778.019 1319.77 Q774.847 1319.77 773.25 1320.74 Q771.676 1321.71 771.676 1323.66 Q771.676 1325.14 772.81 1326 Q773.945 1326.83 777.371 1327.59 L778.829 1327.92 Q783.366 1328.89 785.264 1330.67 Q787.185 1332.43 787.185 1335.6 Q787.185 1339.21 784.315 1341.32 Q781.468 1343.43 776.468 1343.43 Q774.385 1343.43 772.116 1343.01 Q769.871 1342.62 767.371 1341.81 L767.371 1337.41 Q769.732 1338.63 772.023 1339.26 Q774.315 1339.86 776.56 1339.86 Q779.57 1339.86 781.19 1338.84 Q782.81 1337.8 782.81 1335.93 Q782.81 1334.19 781.63 1333.26 Q780.472 1332.34 776.514 1331.48 L775.033 1331.14 Q771.074 1330.3 769.315 1328.59 Q767.556 1326.85 767.556 1323.84 Q767.556 1320.19 770.148 1318.2 Q772.741 1316.2 777.51 1316.2 Q779.871 1316.2 781.954 1316.55 Q784.037 1316.9 785.797 1317.59 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M793.968 1316.83 L798.227 1316.83 L798.227 1342.76 L793.968 1342.76 L793.968 1316.83 M793.968 1306.74 L798.227 1306.74 L798.227 1312.13 L793.968 1312.13 L793.968 1306.74 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M827.324 1321.81 Q828.921 1318.94 831.143 1317.57 Q833.366 1316.2 836.375 1316.2 Q840.426 1316.2 842.625 1319.05 Q844.824 1321.88 844.824 1327.11 L844.824 1342.76 L840.542 1342.76 L840.542 1327.25 Q840.542 1323.52 839.222 1321.71 Q837.903 1319.91 835.194 1319.91 Q831.884 1319.91 829.963 1322.11 Q828.042 1324.31 828.042 1328.1 L828.042 1342.76 L823.759 1342.76 L823.759 1327.25 Q823.759 1323.5 822.44 1321.71 Q821.12 1319.91 818.366 1319.91 Q815.102 1319.91 813.181 1322.13 Q811.259 1324.33 811.259 1328.1 L811.259 1342.76 L806.977 1342.76 L806.977 1316.83 L811.259 1316.83 L811.259 1320.86 Q812.718 1318.47 814.755 1317.34 Q816.792 1316.2 819.593 1316.2 Q822.417 1316.2 824.384 1317.64 Q826.375 1319.07 827.324 1321.81 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M875.495 1328.73 L875.495 1330.81 L855.912 1330.81 Q856.19 1335.21 858.551 1337.52 Q860.935 1339.82 865.171 1339.82 Q867.625 1339.82 869.916 1339.21 Q872.231 1338.61 874.5 1337.41 L874.5 1341.44 Q872.208 1342.41 869.801 1342.92 Q867.393 1343.43 864.916 1343.43 Q858.713 1343.43 855.079 1339.82 Q851.467 1336.2 851.467 1330.05 Q851.467 1323.68 854.893 1319.95 Q858.342 1316.2 864.176 1316.2 Q869.407 1316.2 872.44 1319.58 Q875.495 1322.94 875.495 1328.73 M871.236 1327.48 Q871.19 1323.98 869.268 1321.9 Q867.37 1319.82 864.222 1319.82 Q860.657 1319.82 858.504 1321.83 Q856.375 1323.84 856.051 1327.5 L871.236 1327.48 M867.139 1304.84 L871.745 1304.84 L864.199 1313.54 L860.657 1313.54 L867.139 1304.84 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M886.699 1309.47 L886.699 1316.83 L895.472 1316.83 L895.472 1320.14 L886.699 1320.14 L886.699 1334.21 Q886.699 1337.38 887.555 1338.29 Q888.435 1339.19 891.097 1339.19 L895.472 1339.19 L895.472 1342.76 L891.097 1342.76 Q886.166 1342.76 884.291 1340.93 Q882.416 1339.07 882.416 1334.21 L882.416 1320.14 L879.291 1320.14 L879.291 1316.83 L882.416 1316.83 L882.416 1309.47 L886.699 1309.47 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M916.097 1320.81 Q915.379 1320.39 914.523 1320.21 Q913.689 1320 912.671 1320 Q909.06 1320 907.115 1322.36 Q905.194 1324.7 905.194 1329.1 L905.194 1342.76 L900.912 1342.76 L900.912 1316.83 L905.194 1316.83 L905.194 1320.86 Q906.537 1318.5 908.689 1317.36 Q910.842 1316.2 913.921 1316.2 Q914.361 1316.2 914.893 1316.27 Q915.425 1316.32 916.074 1316.44 L916.097 1320.81 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M920.564 1316.83 L924.824 1316.83 L924.824 1342.76 L920.564 1342.76 L920.564 1316.83 M920.564 1306.74 L924.824 1306.74 L924.824 1312.13 L920.564 1312.13 L920.564 1306.74 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M952.393 1317.82 L952.393 1321.81 Q950.587 1320.81 948.759 1320.32 Q946.953 1319.82 945.101 1319.82 Q940.958 1319.82 938.666 1322.45 Q936.374 1325.07 936.374 1329.82 Q936.374 1334.56 938.666 1337.2 Q940.958 1339.82 945.101 1339.82 Q946.953 1339.82 948.759 1339.33 Q950.587 1338.82 952.393 1337.82 L952.393 1341.76 Q950.61 1342.59 948.689 1343.01 Q946.791 1343.43 944.638 1343.43 Q938.782 1343.43 935.333 1339.75 Q931.884 1336.07 931.884 1329.82 Q931.884 1323.47 935.356 1319.84 Q938.851 1316.2 944.916 1316.2 Q946.884 1316.2 948.759 1316.62 Q950.634 1317.01 952.393 1317.82 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip240)\" d=\"M971.583 1329.72 Q966.421 1329.72 964.43 1330.9 Q962.439 1332.08 962.439 1334.93 Q962.439 1337.2 963.921 1338.54 Q965.425 1339.86 967.995 1339.86 Q971.536 1339.86 973.666 1337.36 Q975.819 1334.84 975.819 1330.67 L975.819 1329.72 L971.583 1329.72 M980.078 1327.96 L980.078 1342.76 L975.819 1342.76 L975.819 1338.82 Q974.36 1341.18 972.184 1342.32 Q970.008 1343.43 966.86 1343.43 Q962.879 1343.43 960.518 1341.2 Q958.18 1338.96 958.18 1335.21 Q958.18 1330.83 961.096 1328.61 Q964.036 1326.39 969.846 1326.39 L975.819 1326.39 L975.819 1325.97 Q975.819 1323.03 973.874 1321.44 Q971.953 1319.82 968.458 1319.82 Q966.235 1319.82 964.129 1320.35 Q962.022 1320.88 960.078 1321.95 L960.078 1318.01 Q962.416 1317.11 964.615 1316.67 Q966.814 1316.2 968.897 1316.2 Q974.522 1316.2 977.3 1319.12 Q980.078 1322.04 980.078 1327.96 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /></svg>\n"
+      ],
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"600\" height=\"400\" viewBox=\"0 0 2400 1600\">\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip190\">\n",
+       "    <rect x=\"0\" y=\"0\" width=\"2400\" height=\"1600\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<path clip-path=\"url(#clip190)\" d=\"M0 1600 L2400 1600 L2400 0 L0 0  Z\" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip191\">\n",
+       "    <rect x=\"480\" y=\"0\" width=\"1681\" height=\"1600\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<path clip-path=\"url(#clip190)\" d=\"M287.366 1423.18 L2352.76 1423.18 L2352.76 47.2441 L287.366 47.2441  Z\" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<defs>\n",
+       "  <clipPath id=\"clip192\">\n",
+       "    <rect x=\"287\" y=\"47\" width=\"2066\" height=\"1377\"/>\n",
+       "  </clipPath>\n",
+       "</defs>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"484.998,1423.18 484.998,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"763.352,1423.18 763.352,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"1041.71,1423.18 1041.71,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"1320.06,1423.18 1320.06,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"1598.42,1423.18 1598.42,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"1876.77,1423.18 1876.77,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"2155.12,1423.18 2155.12,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"287.366,1367.63 2352.76,1367.63 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"287.366,1046.25 2352.76,1046.25 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"287.366,724.881 2352.76,724.881 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"287.366,403.508 2352.76,403.508 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"287.366,82.1342 2352.76,82.1342 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,1423.18 2352.76,1423.18 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"484.998,1423.18 484.998,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"763.352,1423.18 763.352,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"1041.71,1423.18 1041.71,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"1320.06,1423.18 1320.06,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"1598.42,1423.18 1598.42,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"1876.77,1423.18 1876.77,1404.28 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"2155.12,1423.18 2155.12,1404.28 \"/>\n",
+       "<path clip-path=\"url(#clip190)\" d=\"M438.817 1468.75 L468.493 1468.75 L468.493 1472.69 L438.817 1472.69 L438.817 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M479.396 1481.64 L487.035 1481.64 L487.035 1455.28 L478.724 1456.95 L478.724 1452.69 L486.988 1451.02 L491.664 1451.02 L491.664 1481.64 L499.303 1481.64 L499.303 1485.58 L479.396 1485.58 L479.396 1481.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M521.595 1455.09 L509.789 1473.54 L521.595 1473.54 L521.595 1455.09 M520.368 1451.02 L526.247 1451.02 L526.247 1473.54 L531.178 1473.54 L531.178 1477.43 L526.247 1477.43 L526.247 1485.58 L521.595 1485.58 L521.595 1477.43 L505.993 1477.43 L505.993 1472.92 L520.368 1451.02 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M718.213 1468.75 L747.889 1468.75 L747.889 1472.69 L718.213 1472.69 L718.213 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M758.792 1481.64 L766.431 1481.64 L766.431 1455.28 L758.121 1456.95 L758.121 1452.69 L766.384 1451.02 L771.06 1451.02 L771.06 1481.64 L778.699 1481.64 L778.699 1485.58 L758.792 1485.58 L758.792 1481.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M792.171 1481.64 L808.491 1481.64 L808.491 1485.58 L786.546 1485.58 L786.546 1481.64 Q789.208 1478.89 793.792 1474.26 Q798.398 1469.61 799.579 1468.27 Q801.824 1465.74 802.704 1464.01 Q803.606 1462.25 803.606 1460.56 Q803.606 1457.8 801.662 1456.07 Q799.741 1454.33 796.639 1454.33 Q794.44 1454.33 791.986 1455.09 Q789.556 1455.86 786.778 1457.41 L786.778 1452.69 Q789.602 1451.55 792.056 1450.97 Q794.509 1450.39 796.546 1450.39 Q801.917 1450.39 805.111 1453.08 Q808.305 1455.77 808.305 1460.26 Q808.305 1462.39 807.495 1464.31 Q806.708 1466.2 804.602 1468.8 Q804.023 1469.47 800.921 1472.69 Q797.819 1475.88 792.171 1481.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M995.769 1468.75 L1025.44 1468.75 L1025.44 1472.69 L995.769 1472.69 L995.769 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1036.35 1481.64 L1043.99 1481.64 L1043.99 1455.28 L1035.68 1456.95 L1035.68 1452.69 L1043.94 1451.02 L1048.62 1451.02 L1048.62 1481.64 L1056.25 1481.64 L1056.25 1485.58 L1036.35 1485.58 L1036.35 1481.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1075.7 1454.1 Q1072.09 1454.1 1070.26 1457.66 Q1068.45 1461.2 1068.45 1468.33 Q1068.45 1475.44 1070.26 1479.01 Q1072.09 1482.55 1075.7 1482.55 Q1079.33 1482.55 1081.14 1479.01 Q1082.97 1475.44 1082.97 1468.33 Q1082.97 1461.2 1081.14 1457.66 Q1079.33 1454.1 1075.7 1454.1 M1075.7 1450.39 Q1081.51 1450.39 1084.57 1455 Q1087.64 1459.58 1087.64 1468.33 Q1087.64 1477.06 1084.57 1481.67 Q1081.51 1486.25 1075.7 1486.25 Q1069.89 1486.25 1066.81 1481.67 Q1063.75 1477.06 1063.75 1468.33 Q1063.75 1459.58 1066.81 1455 Q1069.89 1450.39 1075.7 1450.39 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1289.25 1468.75 L1318.93 1468.75 L1318.93 1472.69 L1289.25 1472.69 L1289.25 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1339.02 1469.17 Q1335.69 1469.17 1333.76 1470.95 Q1331.87 1472.73 1331.87 1475.86 Q1331.87 1478.98 1333.76 1480.77 Q1335.69 1482.55 1339.02 1482.55 Q1342.35 1482.55 1344.27 1480.77 Q1346.2 1478.96 1346.2 1475.86 Q1346.2 1472.73 1344.27 1470.95 Q1342.38 1469.17 1339.02 1469.17 M1334.34 1467.18 Q1331.33 1466.44 1329.64 1464.38 Q1327.98 1462.32 1327.98 1459.35 Q1327.98 1455.21 1330.92 1452.8 Q1333.88 1450.39 1339.02 1450.39 Q1344.18 1450.39 1347.12 1452.8 Q1350.06 1455.21 1350.06 1459.35 Q1350.06 1462.32 1348.37 1464.38 Q1346.7 1466.44 1343.72 1467.18 Q1347.1 1467.96 1348.97 1470.26 Q1350.87 1472.55 1350.87 1475.86 Q1350.87 1480.88 1347.79 1483.57 Q1344.74 1486.25 1339.02 1486.25 Q1333.3 1486.25 1330.22 1483.57 Q1327.17 1480.88 1327.17 1475.86 Q1327.17 1472.55 1329.07 1470.26 Q1330.96 1467.96 1334.34 1467.18 M1332.63 1459.79 Q1332.63 1462.48 1334.3 1463.98 Q1335.99 1465.49 1339.02 1465.49 Q1342.03 1465.49 1343.72 1463.98 Q1345.43 1462.48 1345.43 1459.79 Q1345.43 1457.11 1343.72 1455.6 Q1342.03 1454.1 1339.02 1454.1 Q1335.99 1454.1 1334.3 1455.6 Q1332.63 1457.11 1332.63 1459.79 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1567.48 1468.75 L1597.15 1468.75 L1597.15 1472.69 L1567.48 1472.69 L1567.48 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1617.82 1466.44 Q1614.68 1466.44 1612.82 1468.59 Q1611 1470.74 1611 1474.49 Q1611 1478.22 1612.82 1480.39 Q1614.68 1482.55 1617.82 1482.55 Q1620.97 1482.55 1622.8 1480.39 Q1624.65 1478.22 1624.65 1474.49 Q1624.65 1470.74 1622.8 1468.59 Q1620.97 1466.44 1617.82 1466.44 M1627.11 1451.78 L1627.11 1456.04 Q1625.35 1455.21 1623.54 1454.77 Q1621.76 1454.33 1620 1454.33 Q1615.37 1454.33 1612.92 1457.45 Q1610.49 1460.58 1610.14 1466.9 Q1611.51 1464.89 1613.57 1463.82 Q1615.63 1462.73 1618.1 1462.73 Q1623.31 1462.73 1626.32 1465.9 Q1629.35 1469.05 1629.35 1474.49 Q1629.35 1479.82 1626.2 1483.03 Q1623.06 1486.25 1617.82 1486.25 Q1611.83 1486.25 1608.66 1481.67 Q1605.49 1477.06 1605.49 1468.33 Q1605.49 1460.14 1609.38 1455.28 Q1613.26 1450.39 1619.82 1450.39 Q1621.57 1450.39 1623.36 1450.74 Q1625.16 1451.09 1627.11 1451.78 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1845.67 1468.75 L1875.35 1468.75 L1875.35 1472.69 L1845.67 1472.69 L1845.67 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1898.29 1455.09 L1886.48 1473.54 L1898.29 1473.54 L1898.29 1455.09 M1897.06 1451.02 L1902.94 1451.02 L1902.94 1473.54 L1907.87 1473.54 L1907.87 1477.43 L1902.94 1477.43 L1902.94 1485.58 L1898.29 1485.58 L1898.29 1477.43 L1882.68 1477.43 L1882.68 1472.92 L1897.06 1451.02 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M2125.07 1468.75 L2154.74 1468.75 L2154.74 1472.69 L2125.07 1472.69 L2125.07 1468.75 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M2168.86 1481.64 L2185.18 1481.64 L2185.18 1485.58 L2163.24 1485.58 L2163.24 1481.64 Q2165.9 1478.89 2170.48 1474.26 Q2175.09 1469.61 2176.27 1468.27 Q2178.52 1465.74 2179.39 1464.01 Q2180.3 1462.25 2180.3 1460.56 Q2180.3 1457.8 2178.35 1456.07 Q2176.43 1454.33 2173.33 1454.33 Q2171.13 1454.33 2168.68 1455.09 Q2166.25 1455.86 2163.47 1457.41 L2163.47 1452.69 Q2166.29 1451.55 2168.75 1450.97 Q2171.2 1450.39 2173.24 1450.39 Q2178.61 1450.39 2181.8 1453.08 Q2185 1455.77 2185 1460.26 Q2185 1462.39 2184.19 1464.31 Q2183.4 1466.2 2181.29 1468.8 Q2180.71 1469.47 2177.61 1472.69 Q2174.51 1475.88 2168.86 1481.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1175.45 1547.58 L1192.6 1547.58 L1192.6 1552.8 L1175.45 1552.8 L1175.45 1547.58 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1201.93 1518.52 L1207.79 1518.52 L1207.79 1568.04 L1201.93 1568.04 L1201.93 1518.52 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1233.85 1536.5 Q1229.14 1536.5 1226.41 1540.19 Q1223.67 1543.85 1223.67 1550.25 Q1223.67 1556.65 1226.37 1560.34 Q1229.11 1564 1233.85 1564 Q1238.53 1564 1241.27 1560.31 Q1244.01 1556.62 1244.01 1550.25 Q1244.01 1543.92 1241.27 1540.23 Q1238.53 1536.5 1233.85 1536.5 M1233.85 1531.54 Q1241.49 1531.54 1245.85 1536.5 Q1250.21 1541.47 1250.21 1550.25 Q1250.21 1559 1245.85 1564 Q1241.49 1568.97 1233.85 1568.97 Q1226.18 1568.97 1221.82 1564 Q1217.49 1559 1217.49 1550.25 Q1217.49 1541.47 1221.82 1536.5 Q1226.18 1531.54 1233.85 1531.54 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1283.38 1549.81 Q1283.38 1543.44 1280.74 1539.94 Q1278.13 1536.44 1273.38 1536.44 Q1268.67 1536.44 1266.03 1539.94 Q1263.42 1543.44 1263.42 1549.81 Q1263.42 1556.14 1266.03 1559.64 Q1268.67 1563.14 1273.38 1563.14 Q1278.13 1563.14 1280.74 1559.64 Q1283.38 1556.14 1283.38 1549.81 M1289.23 1563.62 Q1289.23 1572.72 1285.19 1577.15 Q1281.15 1581.6 1272.81 1581.6 Q1269.72 1581.6 1266.99 1581.13 Q1264.25 1580.68 1261.67 1579.72 L1261.67 1574.03 Q1264.25 1575.43 1266.76 1576.1 Q1269.28 1576.76 1271.89 1576.76 Q1277.65 1576.76 1280.51 1573.74 Q1283.38 1570.75 1283.38 1564.67 L1283.38 1561.77 Q1281.56 1564.92 1278.73 1566.48 Q1275.9 1568.04 1271.95 1568.04 Q1265.4 1568.04 1261.39 1563.05 Q1257.37 1558.05 1257.37 1549.81 Q1257.37 1541.53 1261.39 1536.53 Q1265.4 1531.54 1271.95 1531.54 Q1275.9 1531.54 1278.73 1533.1 Q1281.56 1534.66 1283.38 1537.81 L1283.38 1532.4 L1289.23 1532.4 L1289.23 1563.62 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1303.24 1562.63 L1313.74 1562.63 L1313.74 1526.38 L1302.32 1528.67 L1302.32 1522.82 L1313.68 1520.52 L1320.11 1520.52 L1320.11 1562.63 L1330.61 1562.63 L1330.61 1568.04 L1303.24 1568.04 L1303.24 1562.63 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1357.35 1524.76 Q1352.38 1524.76 1349.87 1529.66 Q1347.39 1534.53 1347.39 1544.33 Q1347.39 1554.1 1349.87 1559 Q1352.38 1563.87 1357.35 1563.87 Q1362.35 1563.87 1364.83 1559 Q1367.34 1554.1 1367.34 1544.33 Q1367.34 1534.53 1364.83 1529.66 Q1362.35 1524.76 1357.35 1524.76 M1357.35 1519.66 Q1365.34 1519.66 1369.54 1526 Q1373.77 1532.3 1373.77 1544.33 Q1373.77 1556.33 1369.54 1562.66 Q1365.34 1568.97 1357.35 1568.97 Q1349.36 1568.97 1345.13 1562.66 Q1340.92 1556.33 1340.92 1544.33 Q1340.92 1532.3 1345.13 1526 Q1349.36 1519.66 1357.35 1519.66 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1398.31 1518.58 Q1394.05 1525.9 1391.98 1533.06 Q1389.91 1540.23 1389.91 1547.58 Q1389.91 1554.93 1391.98 1562.16 Q1394.08 1569.35 1398.31 1576.64 L1393.22 1576.64 Q1388.44 1569.16 1386.06 1561.93 Q1383.7 1554.71 1383.7 1547.58 Q1383.7 1540.48 1386.06 1533.29 Q1388.41 1526.09 1393.22 1518.58 L1398.31 1518.58 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1439.31 1546.53 L1439.31 1568.04 L1433.45 1568.04 L1433.45 1546.72 Q1433.45 1541.66 1431.48 1539.14 Q1429.5 1536.63 1425.56 1536.63 Q1420.81 1536.63 1418.08 1539.65 Q1415.34 1542.68 1415.34 1547.9 L1415.34 1568.04 L1409.45 1568.04 L1409.45 1518.52 L1415.34 1518.52 L1415.34 1537.93 Q1417.44 1534.72 1420.27 1533.13 Q1423.14 1531.54 1426.86 1531.54 Q1433 1531.54 1436.16 1535.36 Q1439.31 1539.14 1439.31 1546.53 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M1450.06 1518.58 L1455.16 1518.58 Q1459.93 1526.09 1462.29 1533.29 Q1464.67 1540.48 1464.67 1547.58 Q1464.67 1554.71 1462.29 1561.93 Q1459.93 1569.16 1455.16 1576.64 L1450.06 1576.64 Q1454.3 1569.35 1456.37 1562.16 Q1458.47 1554.93 1458.47 1547.58 Q1458.47 1540.23 1456.37 1533.06 Q1454.3 1525.9 1450.06 1518.58 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,1423.18 287.366,47.2441 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,1367.63 306.264,1367.63 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,1046.25 306.264,1046.25 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,724.881 306.264,724.881 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,403.508 306.264,403.508 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"287.366,82.1342 306.264,82.1342 \"/>\n",
+       "<path clip-path=\"url(#clip190)\" d=\"M114.26 1368.08 L143.936 1368.08 L143.936 1372.01 L114.26 1372.01 L114.26 1368.08 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M154.839 1380.97 L162.477 1380.97 L162.477 1354.61 L154.167 1356.27 L154.167 1352.02 L162.431 1350.35 L167.107 1350.35 L167.107 1380.97 L174.746 1380.97 L174.746 1384.91 L154.839 1384.91 L154.839 1380.97 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M194.19 1353.43 Q190.579 1353.43 188.75 1356.99 Q186.945 1360.53 186.945 1367.66 Q186.945 1374.77 188.75 1378.33 Q190.579 1381.88 194.19 1381.88 Q197.825 1381.88 199.63 1378.33 Q201.459 1374.77 201.459 1367.66 Q201.459 1360.53 199.63 1356.99 Q197.825 1353.43 194.19 1353.43 M194.19 1349.72 Q200 1349.72 203.056 1354.33 Q206.135 1358.91 206.135 1367.66 Q206.135 1376.39 203.056 1381 Q200 1385.58 194.19 1385.58 Q188.38 1385.58 185.301 1381 Q182.246 1376.39 182.246 1367.66 Q182.246 1358.91 185.301 1354.33 Q188.38 1349.72 194.19 1349.72 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M214.352 1379.03 L219.236 1379.03 L219.236 1384.91 L214.352 1384.91 L214.352 1379.03 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M239.422 1353.43 Q235.81 1353.43 233.982 1356.99 Q232.176 1360.53 232.176 1367.66 Q232.176 1374.77 233.982 1378.33 Q235.81 1381.88 239.422 1381.88 Q243.056 1381.88 244.861 1378.33 Q246.69 1374.77 246.69 1367.66 Q246.69 1360.53 244.861 1356.99 Q243.056 1353.43 239.422 1353.43 M239.422 1349.72 Q245.232 1349.72 248.287 1354.33 Q251.366 1358.91 251.366 1367.66 Q251.366 1376.39 248.287 1381 Q245.232 1385.58 239.422 1385.58 Q233.611 1385.58 230.533 1381 Q227.477 1376.39 227.477 1367.66 Q227.477 1358.91 230.533 1354.33 Q233.611 1349.72 239.422 1349.72 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M145.417 1046.71 L175.093 1046.71 L175.093 1050.64 L145.417 1050.64 L145.417 1046.71 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M184.005 1028.97 L206.227 1028.97 L206.227 1030.97 L193.681 1063.53 L188.797 1063.53 L200.602 1032.91 L184.005 1032.91 L184.005 1028.97 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M215.348 1057.66 L220.232 1057.66 L220.232 1063.53 L215.348 1063.53 L215.348 1057.66 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M230.463 1028.97 L248.82 1028.97 L248.82 1032.91 L234.746 1032.91 L234.746 1041.38 Q235.764 1041.03 236.783 1040.87 Q237.801 1040.69 238.82 1040.69 Q244.607 1040.69 247.986 1043.86 Q251.366 1047.03 251.366 1052.45 Q251.366 1058.03 247.894 1061.13 Q244.421 1064.21 238.102 1064.21 Q235.926 1064.21 233.658 1063.84 Q231.412 1063.47 229.005 1062.72 L229.005 1058.03 Q231.088 1059.16 233.31 1059.72 Q235.533 1060.27 238.009 1060.27 Q242.014 1060.27 244.352 1058.16 Q246.69 1056.06 246.69 1052.45 Q246.69 1048.84 244.352 1046.73 Q242.014 1044.62 238.009 1044.62 Q236.135 1044.62 234.26 1045.04 Q232.408 1045.46 230.463 1046.34 L230.463 1028.97 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M144.422 725.333 L174.098 725.333 L174.098 729.268 L144.422 729.268 L144.422 725.333 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M184.237 707.601 L202.593 707.601 L202.593 711.536 L188.519 711.536 L188.519 720.009 Q189.538 719.661 190.556 719.499 Q191.575 719.314 192.593 719.314 Q198.38 719.314 201.76 722.485 Q205.139 725.657 205.139 731.073 Q205.139 736.652 201.667 739.754 Q198.195 742.833 191.875 742.833 Q189.7 742.833 187.431 742.462 Q185.186 742.092 182.778 741.351 L182.778 736.652 Q184.862 737.786 187.084 738.342 Q189.306 738.897 191.783 738.897 Q195.787 738.897 198.125 736.791 Q200.463 734.684 200.463 731.073 Q200.463 727.462 198.125 725.356 Q195.787 723.249 191.783 723.249 Q189.908 723.249 188.033 723.666 Q186.181 724.083 184.237 724.962 L184.237 707.601 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M214.352 736.282 L219.236 736.282 L219.236 742.161 L214.352 742.161 L214.352 736.282 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M239.422 710.68 Q235.81 710.68 233.982 714.245 Q232.176 717.786 232.176 724.916 Q232.176 732.022 233.982 735.587 Q235.81 739.129 239.422 739.129 Q243.056 739.129 244.861 735.587 Q246.69 732.022 246.69 724.916 Q246.69 717.786 244.861 714.245 Q243.056 710.68 239.422 710.68 M239.422 706.976 Q245.232 706.976 248.287 711.583 Q251.366 716.166 251.366 724.916 Q251.366 733.643 248.287 738.249 Q245.232 742.833 239.422 742.833 Q233.611 742.833 230.533 738.249 Q227.477 733.643 227.477 724.916 Q227.477 716.166 230.533 711.583 Q233.611 706.976 239.422 706.976 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M145.417 403.959 L175.093 403.959 L175.093 407.894 L145.417 407.894 L145.417 403.959 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M189.213 416.853 L205.533 416.853 L205.533 420.788 L183.588 420.788 L183.588 416.853 Q186.251 414.098 190.834 409.468 Q195.44 404.816 196.621 403.473 Q198.866 400.95 199.746 399.214 Q200.649 397.455 200.649 395.765 Q200.649 393.01 198.704 391.274 Q196.783 389.538 193.681 389.538 Q191.482 389.538 189.028 390.302 Q186.598 391.066 183.82 392.617 L183.82 387.894 Q186.644 386.76 189.098 386.181 Q191.551 385.603 193.588 385.603 Q198.959 385.603 202.153 388.288 Q205.348 390.973 205.348 395.464 Q205.348 397.593 204.537 399.515 Q203.75 401.413 201.644 404.005 Q201.065 404.677 197.963 407.894 Q194.862 411.089 189.213 416.853 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M215.348 414.908 L220.232 414.908 L220.232 420.788 L215.348 420.788 L215.348 414.908 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M230.463 386.228 L248.82 386.228 L248.82 390.163 L234.746 390.163 L234.746 398.635 Q235.764 398.288 236.783 398.126 Q237.801 397.941 238.82 397.941 Q244.607 397.941 247.986 401.112 Q251.366 404.283 251.366 409.7 Q251.366 415.278 247.894 418.38 Q244.421 421.459 238.102 421.459 Q235.926 421.459 233.658 421.089 Q231.412 420.718 229.005 419.978 L229.005 415.278 Q231.088 416.413 233.31 416.968 Q235.533 417.524 238.009 417.524 Q242.014 417.524 244.352 415.417 Q246.69 413.311 246.69 409.7 Q246.69 406.089 244.352 403.982 Q242.014 401.876 238.009 401.876 Q236.135 401.876 234.26 402.292 Q232.408 402.709 230.463 403.589 L230.463 386.228 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M194.19 67.9329 Q190.579 67.9329 188.75 71.4977 Q186.945 75.0393 186.945 82.1689 Q186.945 89.2753 188.75 92.8401 Q190.579 96.3818 194.19 96.3818 Q197.825 96.3818 199.63 92.8401 Q201.459 89.2753 201.459 82.1689 Q201.459 75.0393 199.63 71.4977 Q197.825 67.9329 194.19 67.9329 M194.19 64.2292 Q200 64.2292 203.056 68.8356 Q206.135 73.4189 206.135 82.1689 Q206.135 90.8957 203.056 95.5022 Q200 100.085 194.19 100.085 Q188.38 100.085 185.301 95.5022 Q182.246 90.8957 182.246 82.1689 Q182.246 73.4189 185.301 68.8356 Q188.38 64.2292 194.19 64.2292 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M214.352 93.5346 L219.236 93.5346 L219.236 99.4142 L214.352 99.4142 L214.352 93.5346 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M239.422 67.9329 Q235.81 67.9329 233.982 71.4977 Q232.176 75.0393 232.176 82.1689 Q232.176 89.2753 233.982 92.8401 Q235.81 96.3818 239.422 96.3818 Q243.056 96.3818 244.861 92.8401 Q246.69 89.2753 246.69 82.1689 Q246.69 75.0393 244.861 71.4977 Q243.056 67.9329 239.422 67.9329 M239.422 64.2292 Q245.232 64.2292 248.287 68.8356 Q251.366 73.4189 251.366 82.1689 Q251.366 90.8957 248.287 95.5022 Q245.232 100.085 239.422 100.085 Q233.611 100.085 230.533 95.5022 Q227.477 90.8957 227.477 82.1689 Q227.477 73.4189 230.533 68.8356 Q233.611 64.2292 239.422 64.2292 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M14.479 941.127 L14.479 935.27 L64.0042 935.27 L64.0042 941.127 L14.479 941.127 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M32.4621 909.203 Q32.4621 913.913 36.1542 916.651 Q39.8145 919.388 46.212 919.388 Q52.6095 919.388 56.3017 916.682 Q59.9619 913.945 59.9619 909.203 Q59.9619 904.524 56.2698 901.787 Q52.5777 899.049 46.212 899.049 Q39.8781 899.049 36.186 901.787 Q32.4621 904.524 32.4621 909.203 M27.4968 909.203 Q27.4968 901.564 32.4621 897.203 Q37.4273 892.843 46.212 892.843 Q54.9649 892.843 59.9619 897.203 Q64.9272 901.564 64.9272 909.203 Q64.9272 916.873 59.9619 921.234 Q54.9649 925.563 46.212 925.563 Q37.4273 925.563 32.4621 921.234 Q27.4968 916.873 27.4968 909.203 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M45.7664 859.677 Q39.4007 859.677 35.8996 862.319 Q32.3984 864.929 32.3984 869.672 Q32.3984 874.382 35.8996 877.024 Q39.4007 879.634 45.7664 879.634 Q52.1003 879.634 55.6014 877.024 Q59.1026 874.382 59.1026 869.672 Q59.1026 864.929 55.6014 862.319 Q52.1003 859.677 45.7664 859.677 M59.58 853.821 Q68.683 853.821 73.1071 857.863 Q77.5631 861.905 77.5631 870.245 Q77.5631 873.332 77.0857 876.069 Q76.6401 878.806 75.6852 881.385 L69.9879 881.385 Q71.3884 878.806 72.0568 876.292 Q72.7252 873.777 72.7252 871.168 Q72.7252 865.407 69.7015 862.542 Q66.7096 859.677 60.6303 859.677 L57.7339 859.677 Q60.885 861.492 62.4446 864.324 Q64.0042 867.157 64.0042 871.104 Q64.0042 877.661 59.0071 881.671 Q54.01 885.681 45.7664 885.681 Q37.491 885.681 32.4939 881.671 Q27.4968 877.661 27.4968 871.104 Q27.4968 867.157 29.0564 864.324 Q30.616 861.492 33.7671 859.677 L28.3562 859.677 L28.3562 853.821 L59.58 853.821 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M74.8259 814.672 L79.3773 814.672 L79.3773 848.537 L74.8259 848.537 L74.8259 814.672 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M58.5933 807.224 L58.5933 796.721 L22.3406 796.721 L24.6323 808.147 L18.7758 808.147 L16.4842 796.784 L16.4842 790.355 L58.5933 790.355 L58.5933 779.851 L64.0042 779.851 L64.0042 807.224 L58.5933 807.224 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M20.7174 753.116 Q20.7174 758.081 25.6189 760.595 Q30.4887 763.078 40.2919 763.078 Q50.0633 763.078 54.9649 760.595 Q59.8346 758.081 59.8346 753.116 Q59.8346 748.118 54.9649 745.636 Q50.0633 743.121 40.2919 743.121 Q30.4887 743.121 25.6189 745.636 Q20.7174 748.118 20.7174 753.116 M15.6248 753.116 Q15.6248 745.127 21.9587 740.925 Q28.2607 736.692 40.2919 736.692 Q52.2913 736.692 58.6251 740.925 Q64.9272 745.127 64.9272 753.116 Q64.9272 761.104 58.6251 765.338 Q52.2913 769.539 40.2919 769.539 Q28.2607 769.539 21.9587 765.338 Q15.6248 761.104 15.6248 753.116 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M14.5426 712.152 Q21.8632 716.417 29.0246 718.486 Q36.186 720.555 43.5384 720.555 Q50.8908 720.555 58.1159 718.486 Q65.3091 716.385 72.5979 712.152 L72.5979 717.245 Q65.1182 722.019 57.8931 724.406 Q50.668 726.761 43.5384 726.761 Q36.4406 726.761 29.2474 724.406 Q22.0542 722.051 14.5426 717.245 L14.5426 712.152 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M44.7161 670.298 L47.5806 670.298 L47.5806 697.225 Q53.6281 696.843 56.8109 693.596 Q59.9619 690.318 59.9619 684.493 Q59.9619 681.119 59.1344 677.968 Q58.3069 674.785 56.6518 671.666 L62.1899 671.666 Q63.5267 674.817 64.227 678.127 Q64.9272 681.438 64.9272 684.843 Q64.9272 693.373 59.9619 698.37 Q54.9967 703.336 46.5303 703.336 Q37.7774 703.336 32.6531 698.625 Q27.4968 693.883 27.4968 685.862 Q27.4968 678.669 32.1438 674.499 Q36.7589 670.298 44.7161 670.298 M42.9973 676.154 Q38.1912 676.218 35.3266 678.86 Q32.4621 681.469 32.4621 685.798 Q32.4621 690.7 35.2312 693.66 Q38.0002 696.588 43.0292 697.034 L42.9973 676.154 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M33.8307 640.029 Q33.2578 641.015 33.0032 642.193 Q32.7167 643.339 32.7167 644.739 Q32.7167 649.705 35.9632 652.378 Q39.1779 655.02 45.2253 655.02 L64.0042 655.02 L64.0042 660.908 L28.3562 660.908 L28.3562 655.02 L33.8944 655.02 Q30.6479 653.174 29.0883 650.214 Q27.4968 647.254 27.4968 643.021 Q27.4968 642.416 27.5923 641.684 Q27.656 640.952 27.8151 640.061 L33.8307 640.029 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M33.8307 614.375 Q33.2578 615.362 33.0032 616.539 Q32.7167 617.685 32.7167 619.086 Q32.7167 624.051 35.9632 626.724 Q39.1779 629.366 45.2253 629.366 L64.0042 629.366 L64.0042 635.254 L28.3562 635.254 L28.3562 629.366 L33.8944 629.366 Q30.6479 627.52 29.0883 624.56 Q27.4968 621.6 27.4968 617.367 Q27.4968 616.762 27.5923 616.03 Q27.656 615.298 27.8151 614.407 L33.8307 614.375 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M32.4621 595.851 Q32.4621 600.561 36.1542 603.299 Q39.8145 606.036 46.212 606.036 Q52.6095 606.036 56.3017 603.33 Q59.9619 600.593 59.9619 595.851 Q59.9619 591.172 56.2698 588.435 Q52.5777 585.697 46.212 585.697 Q39.8781 585.697 36.186 588.435 Q32.4621 591.172 32.4621 595.851 M27.4968 595.851 Q27.4968 588.212 32.4621 583.851 Q37.4273 579.491 46.212 579.491 Q54.9649 579.491 59.9619 583.851 Q64.9272 588.212 64.9272 595.851 Q64.9272 603.521 59.9619 607.882 Q54.9649 612.211 46.212 612.211 Q37.4273 612.211 32.4621 607.882 Q27.4968 603.521 27.4968 595.851 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M33.8307 549.126 Q33.2578 550.113 33.0032 551.291 Q32.7167 552.437 32.7167 553.837 Q32.7167 558.802 35.9632 561.476 Q39.1779 564.118 45.2253 564.118 L64.0042 564.118 L64.0042 570.006 L28.3562 570.006 L28.3562 564.118 L33.8944 564.118 Q30.6479 562.272 29.0883 559.312 Q27.4968 556.352 27.4968 552.118 Q27.4968 551.514 27.5923 550.782 Q27.656 550.049 27.8151 549.158 L33.8307 549.126 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M14.5426 543.907 L14.5426 538.814 Q22.0542 534.04 29.2474 531.684 Q36.4406 529.297 43.5384 529.297 Q50.668 529.297 57.8931 531.684 Q65.1182 534.04 72.5979 538.814 L72.5979 543.907 Q65.3091 539.673 58.1159 537.605 Q50.8908 535.504 43.5384 535.504 Q36.186 535.504 29.0246 537.605 Q21.8632 539.673 14.5426 543.907 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><polyline clip-path=\"url(#clip192)\" style=\"stroke:#009af9; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"2294.3,86.1857 2155.12,216.38 2015.95,345.097 1876.77,473.663 1737.59,602.214 1598.42,730.767 1459.24,859.032 1320.06,1042.01 1180.88,869.89 1041.71,869.89 902.529,869.89 763.352,480.233 624.175,357.623 484.998,279.031 345.82,96.7284 \"/>\n",
+       "<polyline clip-path=\"url(#clip192)\" style=\"stroke:#e26f46; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"2294.3,277.899 2155.12,534.998 2015.95,792.097 1876.77,1049.21 1737.59,1305.7 1598.42,1384.24 1459.24,1250.57 1320.06,1108.94 1180.88,920.54 1041.71,869.89 902.529,869.89 763.352,525.441 624.175,411.254 484.998,279.031 345.82,144.731 \"/>\n",
+       "<path clip-path=\"url(#clip190)\" d=\"M356.212 1377.32 L1003.03 1377.32 L1003.03 1221.8 L356.212 1221.8  Z\" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#000000; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"356.212,1377.32 1003.03,1377.32 1003.03,1221.8 356.212,1221.8 356.212,1377.32 \"/>\n",
+       "<polyline clip-path=\"url(#clip190)\" style=\"stroke:#009af9; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"379.161,1273.64 516.854,1273.64 \"/>\n",
+       "<path clip-path=\"url(#clip190)\" d=\"M544.478 1260.2 L544.478 1287.07 L550.126 1287.07 Q557.279 1287.07 560.589 1283.83 Q563.923 1280.59 563.923 1273.6 Q563.923 1266.66 560.589 1263.44 Q557.279 1260.2 550.126 1260.2 L544.478 1260.2 M539.802 1256.36 L549.409 1256.36 Q559.455 1256.36 564.154 1260.55 Q568.853 1264.71 568.853 1273.6 Q568.853 1282.54 564.131 1286.73 Q559.409 1290.92 549.409 1290.92 L539.802 1290.92 L539.802 1256.36 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M598.298 1276.89 L598.298 1278.97 L578.714 1278.97 Q578.992 1283.37 581.353 1285.68 Q583.737 1287.98 587.973 1287.98 Q590.427 1287.98 592.719 1287.37 Q595.034 1286.77 597.302 1285.57 L597.302 1289.6 Q595.01 1290.57 592.603 1291.08 Q590.196 1291.59 587.719 1291.59 Q581.515 1291.59 577.881 1287.98 Q574.27 1284.36 574.27 1278.21 Q574.27 1271.84 577.696 1268.11 Q581.145 1264.36 586.978 1264.36 Q592.21 1264.36 595.242 1267.74 Q598.298 1271.1 598.298 1276.89 M594.038 1275.64 Q593.992 1272.14 592.071 1270.06 Q590.173 1267.98 587.024 1267.98 Q583.46 1267.98 581.307 1269.99 Q579.177 1272 578.853 1275.66 L594.038 1275.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M620.311 1268.97 Q619.594 1268.55 618.737 1268.37 Q617.904 1268.16 616.885 1268.16 Q613.274 1268.16 611.33 1270.52 Q609.409 1272.86 609.409 1277.26 L609.409 1290.92 L605.126 1290.92 L605.126 1264.99 L609.409 1264.99 L609.409 1269.02 Q610.751 1266.66 612.904 1265.52 Q615.057 1264.36 618.135 1264.36 Q618.575 1264.36 619.108 1264.43 Q619.64 1264.48 620.288 1264.6 L620.311 1268.97 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M624.779 1264.99 L629.038 1264.99 L629.038 1290.92 L624.779 1290.92 L624.779 1264.99 M624.779 1254.9 L629.038 1254.9 L629.038 1260.29 L624.779 1260.29 L624.779 1254.9 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M634.895 1264.99 L639.408 1264.99 L647.51 1286.75 L655.612 1264.99 L660.126 1264.99 L650.404 1290.92 L644.617 1290.92 L634.895 1264.99 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M677.788 1277.88 Q672.626 1277.88 670.635 1279.06 Q668.644 1280.24 668.644 1283.09 Q668.644 1285.36 670.126 1286.7 Q671.63 1288.02 674.2 1288.02 Q677.742 1288.02 679.871 1285.52 Q682.024 1283 682.024 1278.83 L682.024 1277.88 L677.788 1277.88 M686.283 1276.12 L686.283 1290.92 L682.024 1290.92 L682.024 1286.98 Q680.566 1289.34 678.39 1290.48 Q676.214 1291.59 673.066 1291.59 Q669.084 1291.59 666.723 1289.36 Q664.385 1287.12 664.385 1283.37 Q664.385 1278.99 667.302 1276.77 Q670.242 1274.55 676.052 1274.55 L682.024 1274.55 L682.024 1274.13 Q682.024 1271.19 680.079 1269.6 Q678.158 1267.98 674.663 1267.98 Q672.441 1267.98 670.334 1268.51 Q668.228 1269.04 666.283 1270.11 L666.283 1266.17 Q668.621 1265.27 670.82 1264.83 Q673.019 1264.36 675.103 1264.36 Q680.728 1264.36 683.505 1267.28 Q686.283 1270.2 686.283 1276.12 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M712.116 1268.92 L712.116 1254.9 L716.376 1254.9 L716.376 1290.92 L712.116 1290.92 L712.116 1287.03 Q710.774 1289.34 708.714 1290.48 Q706.677 1291.59 703.806 1291.59 Q699.107 1291.59 696.144 1287.84 Q693.204 1284.09 693.204 1277.98 Q693.204 1271.86 696.144 1268.11 Q699.107 1264.36 703.806 1264.36 Q706.677 1264.36 708.714 1265.5 Q710.774 1266.61 712.116 1268.92 M697.603 1277.98 Q697.603 1282.67 699.524 1285.36 Q701.468 1288.02 704.848 1288.02 Q708.227 1288.02 710.172 1285.36 Q712.116 1282.67 712.116 1277.98 Q712.116 1273.28 710.172 1270.61 Q708.227 1267.93 704.848 1267.93 Q701.468 1267.93 699.524 1270.61 Q697.603 1273.28 697.603 1277.98 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M736.931 1277.88 Q731.769 1277.88 729.778 1279.06 Q727.788 1280.24 727.788 1283.09 Q727.788 1285.36 729.269 1286.7 Q730.774 1288.02 733.343 1288.02 Q736.885 1288.02 739.014 1285.52 Q741.167 1283 741.167 1278.83 L741.167 1277.88 L736.931 1277.88 M745.426 1276.12 L745.426 1290.92 L741.167 1290.92 L741.167 1286.98 Q739.709 1289.34 737.533 1290.48 Q735.357 1291.59 732.209 1291.59 Q728.227 1291.59 725.866 1289.36 Q723.528 1287.12 723.528 1283.37 Q723.528 1278.99 726.445 1276.77 Q729.385 1274.55 735.195 1274.55 L741.167 1274.55 L741.167 1274.13 Q741.167 1271.19 739.223 1269.6 Q737.301 1267.98 733.806 1267.98 Q731.584 1267.98 729.477 1268.51 Q727.371 1269.04 725.426 1270.11 L725.426 1266.17 Q727.764 1265.27 729.963 1264.83 Q732.163 1264.36 734.246 1264.36 Q739.871 1264.36 742.649 1267.28 Q745.426 1270.2 745.426 1276.12 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M786.329 1268.92 L786.329 1254.9 L790.588 1254.9 L790.588 1290.92 L786.329 1290.92 L786.329 1287.03 Q784.986 1289.34 782.926 1290.48 Q780.889 1291.59 778.019 1291.59 Q773.32 1291.59 770.357 1287.84 Q767.417 1284.09 767.417 1277.98 Q767.417 1271.86 770.357 1268.11 Q773.32 1264.36 778.019 1264.36 Q780.889 1264.36 782.926 1265.5 Q784.986 1266.61 786.329 1268.92 M771.815 1277.98 Q771.815 1282.67 773.736 1285.36 Q775.681 1288.02 779.06 1288.02 Q782.44 1288.02 784.384 1285.36 Q786.329 1282.67 786.329 1277.98 Q786.329 1273.28 784.384 1270.61 Q782.44 1267.93 779.06 1267.93 Q775.681 1267.93 773.736 1270.61 Q771.815 1273.28 771.815 1277.98 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M821.537 1276.89 L821.537 1278.97 L801.954 1278.97 Q802.232 1283.37 804.593 1285.68 Q806.977 1287.98 811.213 1287.98 Q813.667 1287.98 815.958 1287.37 Q818.273 1286.77 820.542 1285.57 L820.542 1289.6 Q818.25 1290.57 815.843 1291.08 Q813.435 1291.59 810.958 1291.59 Q804.755 1291.59 801.121 1287.98 Q797.509 1284.36 797.509 1278.21 Q797.509 1271.84 800.935 1268.11 Q804.384 1264.36 810.218 1264.36 Q815.449 1264.36 818.482 1267.74 Q821.537 1271.1 821.537 1276.89 M817.278 1275.64 Q817.232 1272.14 815.31 1270.06 Q813.412 1267.98 810.264 1267.98 Q806.699 1267.98 804.546 1269.99 Q802.417 1272 802.093 1275.66 L817.278 1275.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M843.551 1268.97 Q842.833 1268.55 841.977 1268.37 Q841.143 1268.16 840.125 1268.16 Q836.514 1268.16 834.569 1270.52 Q832.648 1272.86 832.648 1277.26 L832.648 1290.92 L828.366 1290.92 L828.366 1264.99 L832.648 1264.99 L832.648 1269.02 Q833.991 1266.66 836.143 1265.52 Q838.296 1264.36 841.375 1264.36 Q841.815 1264.36 842.347 1264.43 Q842.88 1264.48 843.528 1264.6 L843.551 1268.97 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M869.153 1276.89 L869.153 1278.97 L849.569 1278.97 Q849.847 1283.37 852.208 1285.68 Q854.592 1287.98 858.829 1287.98 Q861.282 1287.98 863.574 1287.37 Q865.889 1286.77 868.157 1285.57 L868.157 1289.6 Q865.866 1290.57 863.458 1291.08 Q861.051 1291.59 858.574 1291.59 Q852.37 1291.59 848.736 1287.98 Q845.125 1284.36 845.125 1278.21 Q845.125 1271.84 848.551 1268.11 Q852 1264.36 857.833 1264.36 Q863.065 1264.36 866.097 1267.74 Q869.153 1271.1 869.153 1276.89 M864.893 1275.64 Q864.847 1272.14 862.926 1270.06 Q861.028 1267.98 857.879 1267.98 Q854.315 1267.98 852.162 1269.99 Q850.032 1272 849.708 1275.66 L864.893 1275.64 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M894.801 1265.98 L894.801 1269.97 Q892.995 1268.97 891.166 1268.48 Q889.361 1267.98 887.509 1267.98 Q883.365 1267.98 881.074 1270.61 Q878.782 1273.23 878.782 1277.98 Q878.782 1282.72 881.074 1285.36 Q883.365 1287.98 887.509 1287.98 Q889.361 1287.98 891.166 1287.49 Q892.995 1286.98 894.801 1285.98 L894.801 1289.92 Q893.018 1290.75 891.097 1291.17 Q889.199 1291.59 887.046 1291.59 Q881.19 1291.59 877.74 1287.91 Q874.291 1284.23 874.291 1277.98 Q874.291 1271.63 877.764 1268 Q881.259 1264.36 887.324 1264.36 Q889.291 1264.36 891.166 1264.78 Q893.041 1265.17 894.801 1265.98 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M923.759 1275.27 L923.759 1290.92 L919.499 1290.92 L919.499 1275.41 Q919.499 1271.73 918.064 1269.9 Q916.629 1268.07 913.759 1268.07 Q910.31 1268.07 908.319 1270.27 Q906.328 1272.47 906.328 1276.26 L906.328 1290.92 L902.046 1290.92 L902.046 1254.9 L906.328 1254.9 L906.328 1269.02 Q907.856 1266.68 909.916 1265.52 Q912 1264.36 914.708 1264.36 Q919.175 1264.36 921.467 1267.14 Q923.759 1269.9 923.759 1275.27 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M944.036 1277.88 Q938.874 1277.88 936.884 1279.06 Q934.893 1280.24 934.893 1283.09 Q934.893 1285.36 936.374 1286.7 Q937.879 1288.02 940.448 1288.02 Q943.99 1288.02 946.12 1285.52 Q948.272 1283 948.272 1278.83 L948.272 1277.88 L944.036 1277.88 M952.532 1276.12 L952.532 1290.92 L948.272 1290.92 L948.272 1286.98 Q946.814 1289.34 944.638 1290.48 Q942.462 1291.59 939.314 1291.59 Q935.333 1291.59 932.972 1289.36 Q930.634 1287.12 930.634 1283.37 Q930.634 1278.99 933.55 1276.77 Q936.49 1274.55 942.3 1274.55 L948.272 1274.55 L948.272 1274.13 Q948.272 1271.19 946.328 1269.6 Q944.407 1267.98 940.911 1267.98 Q938.689 1267.98 936.583 1268.51 Q934.476 1269.04 932.532 1270.11 L932.532 1266.17 Q934.87 1265.27 937.069 1264.83 Q939.268 1264.36 941.351 1264.36 Q946.976 1264.36 949.754 1267.28 Q952.532 1270.2 952.532 1276.12 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><polyline clip-path=\"url(#clip190)\" style=\"stroke:#e26f46; stroke-linecap:round; stroke-linejoin:round; stroke-width:4; stroke-opacity:1; fill:none\" points=\"379.161,1325.48 516.854,1325.48 \"/>\n",
+       "<path clip-path=\"url(#clip190)\" d=\"M544.478 1312.04 L544.478 1338.91 L550.126 1338.91 Q557.279 1338.91 560.589 1335.67 Q563.923 1332.43 563.923 1325.44 Q563.923 1318.5 560.589 1315.28 Q557.279 1312.04 550.126 1312.04 L544.478 1312.04 M539.802 1308.2 L549.409 1308.2 Q559.455 1308.2 564.154 1312.39 Q568.853 1316.55 568.853 1325.44 Q568.853 1334.38 564.131 1338.57 Q559.409 1342.76 549.409 1342.76 L539.802 1342.76 L539.802 1308.2 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M598.298 1328.73 L598.298 1330.81 L578.714 1330.81 Q578.992 1335.21 581.353 1337.52 Q583.737 1339.82 587.973 1339.82 Q590.427 1339.82 592.719 1339.21 Q595.034 1338.61 597.302 1337.41 L597.302 1341.44 Q595.01 1342.41 592.603 1342.92 Q590.196 1343.43 587.719 1343.43 Q581.515 1343.43 577.881 1339.82 Q574.27 1336.2 574.27 1330.05 Q574.27 1323.68 577.696 1319.95 Q581.145 1316.2 586.978 1316.2 Q592.21 1316.2 595.242 1319.58 Q598.298 1322.94 598.298 1328.73 M594.038 1327.48 Q593.992 1323.98 592.071 1321.9 Q590.173 1319.82 587.024 1319.82 Q583.46 1319.82 581.307 1321.83 Q579.177 1323.84 578.853 1327.5 L594.038 1327.48 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M620.311 1320.81 Q619.594 1320.39 618.737 1320.21 Q617.904 1320 616.885 1320 Q613.274 1320 611.33 1322.36 Q609.409 1324.7 609.409 1329.1 L609.409 1342.76 L605.126 1342.76 L605.126 1316.83 L609.409 1316.83 L609.409 1320.86 Q610.751 1318.5 612.904 1317.36 Q615.057 1316.2 618.135 1316.2 Q618.575 1316.2 619.108 1316.27 Q619.64 1316.32 620.288 1316.44 L620.311 1320.81 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M624.779 1316.83 L629.038 1316.83 L629.038 1342.76 L624.779 1342.76 L624.779 1316.83 M624.779 1306.74 L629.038 1306.74 L629.038 1312.13 L624.779 1312.13 L624.779 1306.74 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M634.895 1316.83 L639.408 1316.83 L647.51 1338.59 L655.612 1316.83 L660.126 1316.83 L650.404 1342.76 L644.617 1342.76 L634.895 1316.83 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M677.788 1329.72 Q672.626 1329.72 670.635 1330.9 Q668.644 1332.08 668.644 1334.93 Q668.644 1337.2 670.126 1338.54 Q671.63 1339.86 674.2 1339.86 Q677.742 1339.86 679.871 1337.36 Q682.024 1334.84 682.024 1330.67 L682.024 1329.72 L677.788 1329.72 M686.283 1327.96 L686.283 1342.76 L682.024 1342.76 L682.024 1338.82 Q680.566 1341.18 678.39 1342.32 Q676.214 1343.43 673.066 1343.43 Q669.084 1343.43 666.723 1341.2 Q664.385 1338.96 664.385 1335.21 Q664.385 1330.83 667.302 1328.61 Q670.242 1326.39 676.052 1326.39 L682.024 1326.39 L682.024 1325.97 Q682.024 1323.03 680.079 1321.44 Q678.158 1319.82 674.663 1319.82 Q672.441 1319.82 670.334 1320.35 Q668.228 1320.88 666.283 1321.95 L666.283 1318.01 Q668.621 1317.11 670.82 1316.67 Q673.019 1316.2 675.103 1316.2 Q680.728 1316.2 683.505 1319.12 Q686.283 1322.04 686.283 1327.96 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M712.116 1320.76 L712.116 1306.74 L716.376 1306.74 L716.376 1342.76 L712.116 1342.76 L712.116 1338.87 Q710.774 1341.18 708.714 1342.32 Q706.677 1343.43 703.806 1343.43 Q699.107 1343.43 696.144 1339.68 Q693.204 1335.93 693.204 1329.82 Q693.204 1323.7 696.144 1319.95 Q699.107 1316.2 703.806 1316.2 Q706.677 1316.2 708.714 1317.34 Q710.774 1318.45 712.116 1320.76 M697.603 1329.82 Q697.603 1334.51 699.524 1337.2 Q701.468 1339.86 704.848 1339.86 Q708.227 1339.86 710.172 1337.2 Q712.116 1334.51 712.116 1329.82 Q712.116 1325.12 710.172 1322.45 Q708.227 1319.77 704.848 1319.77 Q701.468 1319.77 699.524 1322.45 Q697.603 1325.12 697.603 1329.82 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M736.931 1329.72 Q731.769 1329.72 729.778 1330.9 Q727.788 1332.08 727.788 1334.93 Q727.788 1337.2 729.269 1338.54 Q730.774 1339.86 733.343 1339.86 Q736.885 1339.86 739.014 1337.36 Q741.167 1334.84 741.167 1330.67 L741.167 1329.72 L736.931 1329.72 M745.426 1327.96 L745.426 1342.76 L741.167 1342.76 L741.167 1338.82 Q739.709 1341.18 737.533 1342.32 Q735.357 1343.43 732.209 1343.43 Q728.227 1343.43 725.866 1341.2 Q723.528 1338.96 723.528 1335.21 Q723.528 1330.83 726.445 1328.61 Q729.385 1326.39 735.195 1326.39 L741.167 1326.39 L741.167 1325.97 Q741.167 1323.03 739.223 1321.44 Q737.301 1319.82 733.806 1319.82 Q731.584 1319.82 729.477 1320.35 Q727.371 1320.88 725.426 1321.95 L725.426 1318.01 Q727.764 1317.11 729.963 1316.67 Q732.163 1316.2 734.246 1316.2 Q739.871 1316.2 742.649 1319.12 Q745.426 1322.04 745.426 1327.96 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M785.797 1317.59 L785.797 1321.62 Q783.991 1320.7 782.047 1320.23 Q780.102 1319.77 778.019 1319.77 Q774.847 1319.77 773.25 1320.74 Q771.676 1321.71 771.676 1323.66 Q771.676 1325.14 772.81 1326 Q773.945 1326.83 777.371 1327.59 L778.829 1327.92 Q783.366 1328.89 785.264 1330.67 Q787.185 1332.43 787.185 1335.6 Q787.185 1339.21 784.315 1341.32 Q781.468 1343.43 776.468 1343.43 Q774.385 1343.43 772.116 1343.01 Q769.871 1342.62 767.371 1341.81 L767.371 1337.41 Q769.732 1338.63 772.023 1339.26 Q774.315 1339.86 776.56 1339.86 Q779.57 1339.86 781.19 1338.84 Q782.81 1337.8 782.81 1335.93 Q782.81 1334.19 781.63 1333.26 Q780.472 1332.34 776.514 1331.48 L775.033 1331.14 Q771.074 1330.3 769.315 1328.59 Q767.556 1326.85 767.556 1323.84 Q767.556 1320.19 770.148 1318.2 Q772.741 1316.2 777.51 1316.2 Q779.871 1316.2 781.954 1316.55 Q784.037 1316.9 785.797 1317.59 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M793.968 1316.83 L798.227 1316.83 L798.227 1342.76 L793.968 1342.76 L793.968 1316.83 M793.968 1306.74 L798.227 1306.74 L798.227 1312.13 L793.968 1312.13 L793.968 1306.74 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M827.324 1321.81 Q828.921 1318.94 831.143 1317.57 Q833.366 1316.2 836.375 1316.2 Q840.426 1316.2 842.625 1319.05 Q844.824 1321.88 844.824 1327.11 L844.824 1342.76 L840.542 1342.76 L840.542 1327.25 Q840.542 1323.52 839.222 1321.71 Q837.903 1319.91 835.194 1319.91 Q831.884 1319.91 829.963 1322.11 Q828.042 1324.31 828.042 1328.1 L828.042 1342.76 L823.759 1342.76 L823.759 1327.25 Q823.759 1323.5 822.44 1321.71 Q821.12 1319.91 818.366 1319.91 Q815.102 1319.91 813.181 1322.13 Q811.259 1324.33 811.259 1328.1 L811.259 1342.76 L806.977 1342.76 L806.977 1316.83 L811.259 1316.83 L811.259 1320.86 Q812.718 1318.47 814.755 1317.34 Q816.792 1316.2 819.593 1316.2 Q822.417 1316.2 824.384 1317.64 Q826.375 1319.07 827.324 1321.81 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M875.495 1328.73 L875.495 1330.81 L855.912 1330.81 Q856.19 1335.21 858.551 1337.52 Q860.935 1339.82 865.171 1339.82 Q867.625 1339.82 869.916 1339.21 Q872.231 1338.61 874.5 1337.41 L874.5 1341.44 Q872.208 1342.41 869.801 1342.92 Q867.393 1343.43 864.916 1343.43 Q858.713 1343.43 855.079 1339.82 Q851.467 1336.2 851.467 1330.05 Q851.467 1323.68 854.893 1319.95 Q858.342 1316.2 864.176 1316.2 Q869.407 1316.2 872.44 1319.58 Q875.495 1322.94 875.495 1328.73 M871.236 1327.48 Q871.19 1323.98 869.268 1321.9 Q867.37 1319.82 864.222 1319.82 Q860.657 1319.82 858.504 1321.83 Q856.375 1323.84 856.051 1327.5 L871.236 1327.48 M867.139 1304.84 L871.745 1304.84 L864.199 1313.54 L860.657 1313.54 L867.139 1304.84 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M886.699 1309.47 L886.699 1316.83 L895.472 1316.83 L895.472 1320.14 L886.699 1320.14 L886.699 1334.21 Q886.699 1337.38 887.555 1338.29 Q888.435 1339.19 891.097 1339.19 L895.472 1339.19 L895.472 1342.76 L891.097 1342.76 Q886.166 1342.76 884.291 1340.93 Q882.416 1339.07 882.416 1334.21 L882.416 1320.14 L879.291 1320.14 L879.291 1316.83 L882.416 1316.83 L882.416 1309.47 L886.699 1309.47 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M916.097 1320.81 Q915.379 1320.39 914.523 1320.21 Q913.689 1320 912.671 1320 Q909.06 1320 907.115 1322.36 Q905.194 1324.7 905.194 1329.1 L905.194 1342.76 L900.912 1342.76 L900.912 1316.83 L905.194 1316.83 L905.194 1320.86 Q906.537 1318.5 908.689 1317.36 Q910.842 1316.2 913.921 1316.2 Q914.361 1316.2 914.893 1316.27 Q915.425 1316.32 916.074 1316.44 L916.097 1320.81 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M920.564 1316.83 L924.824 1316.83 L924.824 1342.76 L920.564 1342.76 L920.564 1316.83 M920.564 1306.74 L924.824 1306.74 L924.824 1312.13 L920.564 1312.13 L920.564 1306.74 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M952.393 1317.82 L952.393 1321.81 Q950.587 1320.81 948.759 1320.32 Q946.953 1319.82 945.101 1319.82 Q940.958 1319.82 938.666 1322.45 Q936.374 1325.07 936.374 1329.82 Q936.374 1334.56 938.666 1337.2 Q940.958 1339.82 945.101 1339.82 Q946.953 1339.82 948.759 1339.33 Q950.587 1338.82 952.393 1337.82 L952.393 1341.76 Q950.61 1342.59 948.689 1343.01 Q946.791 1343.43 944.638 1343.43 Q938.782 1343.43 935.333 1339.75 Q931.884 1336.07 931.884 1329.82 Q931.884 1323.47 935.356 1319.84 Q938.851 1316.2 944.916 1316.2 Q946.884 1316.2 948.759 1316.62 Q950.634 1317.01 952.393 1317.82 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /><path clip-path=\"url(#clip190)\" d=\"M971.583 1329.72 Q966.421 1329.72 964.43 1330.9 Q962.439 1332.08 962.439 1334.93 Q962.439 1337.2 963.921 1338.54 Q965.425 1339.86 967.995 1339.86 Q971.536 1339.86 973.666 1337.36 Q975.819 1334.84 975.819 1330.67 L975.819 1329.72 L971.583 1329.72 M980.078 1327.96 L980.078 1342.76 L975.819 1342.76 L975.819 1338.82 Q974.36 1341.18 972.184 1342.32 Q970.008 1343.43 966.86 1343.43 Q962.879 1343.43 960.518 1341.2 Q958.18 1338.96 958.18 1335.21 Q958.18 1330.83 961.096 1328.61 Q964.036 1326.39 969.846 1326.39 L975.819 1326.39 L975.819 1325.97 Q975.819 1323.03 973.874 1321.44 Q971.953 1319.82 968.458 1319.82 Q966.235 1319.82 964.129 1320.35 Q962.022 1320.88 960.078 1321.95 L960.078 1318.01 Q962.416 1317.11 964.615 1316.67 Q966.814 1316.2 968.897 1316.2 Q974.522 1316.2 977.3 1319.12 Q980.078 1322.04 980.078 1327.96 Z\" fill=\"#000000\" fill-rule=\"nonzero\" fill-opacity=\"1\" /></svg>\n"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 15
+    }
+   ],
+   "cell_type": "code",
+   "source": [
+    "using Plots\n",
+    "\n",
+    "plot(-(1:15), log10.(errs_dd), xlabel=\"-log10(h)\", ylabel=\"log_10(error)\", label=\"Derivada derecha\", legend=:bottomleft)\n",
+    "plot!(-(1:15), log10.(errs_ds), xlabel=\"-log10(h)\", ylabel=\"log_10(error)\", label=\"Derivada simétrica\")"
+   ],
+   "metadata": {},
+   "execution_count": 15
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Los puntos anteriores muestran que al implementar un algoritmo\n",
+    "numéricamente (usando números de punto flotante u otros con\n",
+    "*precisión finita*) es importante la manera en que se hace,\n",
+    "y cuestiones de convergencia y manejo de errores\n",
+    "numéricos se vuelven importantes."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Diferenciación automática"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "La pregunta es si podemos obtener el valor exacto,\n",
+    "en un sentido numérico, usando números de punto flotante,\n",
+    "y en la medida de lo posible hacer esto de forma independiente de $h$.\n",
+    "Esto es, obtener como resultado el valor que más se acerca al valor\n",
+    "que se obtendría usando números reales, excepto quizás por cuestiones\n",
+    "inevitables de redondeo. Las técnicas que introduciremos se conocen como\n",
+    "*diferenciación automática* o *algorítmica*."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Preludio: álgebra de los números complejos"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Antes de ilustrar cómo funcionan los *números duales*, que introduciremos\n",
+    "más adelante, empezaremos recordando el álgebra de los números complejos:\n",
+    "$z = a + \\mathrm{i} b$, donde $a$\n",
+    "representa la parte real de $z$, $b$ es su parte imaginaria, y donde\n",
+    "$\\mathrm{i}^2=-1$."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Uno puede definir todas las operaciones aritméticas de *manera\n",
+    "natural* (a partir de los números reales), manteniendo las expresiones\n",
+    "con $\\mathrm{i}$ factorizada. En el caso de la multiplicación (y la\n",
+    "división) debemos explotar el hecho que $\\mathrm{i}^2=-1$, que es\n",
+    "la propiedad que *define* al número imaginario $\\mathrm{i}$;\n",
+    "este punto será clave más adelante con extendamos este\n",
+    "tipo de análisis a los números duales."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "De esta manera, para $z = a + \\mathrm{i} b$ y $w = c + \\mathrm{i} d$,\n",
+    "tenemos que,\n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "z \\pm w & = (a + \\mathrm{i} b) \\pm (c + \\mathrm{i} d) = (a \\pm c) + \\mathrm{i}(b \\pm d),\\\\\n",
+    "z \\cdot w & = (a + \\mathrm{i} b)\\cdot (c + \\mathrm{i} d)\n",
+    "  = ac + \\mathrm{i} (ad+bc) + \\mathrm{i}^2 b d\\\\\n",
+    " & = (ac - b d) + \\mathrm{i} (ad+bc).\\\\\n",
+    "\\end{align*}\n",
+    "$$"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Por último, vale la pena recordar que $\\mathbb{C}$ es\n",
+    "*isomorfo* a $\\mathbb{R}^2$, esto es, uno puede asociar un punto\n",
+    "en $\\mathbb{C}$ con uno en $\\mathbb{R}^2$ de manera unívoca, y\n",
+    "visceversa."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Números duales"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "De manera análoga a los números complejos, introduciremos un par\n",
+    "ordenado que definirá a los *números duales*, donde la primer componente\n",
+    "es el valor de una función $f(x)$ evaluada en un punto $x_0$ dado, y\n",
+    "la segunda es el valor de su derivada evaluada en el mismo punto.\n",
+    "Esto es, definimos a los *duales* como:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "$$\n",
+    "\\mathbb{D}_{x_0}f = \\big( f(x_0), f'(x_0) \\big) = \\big( f_0, f'_0 \\big) =\n",
+    "f_0 + \\epsilon\\, f'_0.\n",
+    "$$"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Aquí $f_0 = f(x_0)$ y $f'_0=\\frac{d f}{d x}(x_0)$ y, en la última\n",
+    "igualdad, $\\epsilon$ sirve para indicar la segunda componente del\n",
+    "par ordenado. En un sentido que se precisará más adelante, $\\epsilon$\n",
+    "se comporta de manera parecida a $\\mathrm{i}$ para los números\n",
+    "complejos: mientras $\\mathrm{i}$ distingue la parte real y la parte\n",
+    "imaginaria de un número complejo, $\\epsilon$ distinguirá la parte\n",
+    "función de la parte derivada en los números duales."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "En particular, para la función constante $f(x)=c$, cuya valor\n",
+    "es independiente de la variable (independiente) $x$, se debe cumplir\n",
+    "que el dual asociado sea\n",
+    "$$\n",
+    "\\mathbb{D}_{x_0}c = (c, 0) = c,\n",
+    "$$\n",
+    "y para la función\n",
+    "identidad $f(x)=x$ tendremos\n",
+    "$$\n",
+    "\\mathbb{D}_{x_0} x =(x_0,1) = x_0 + \\epsilon.\n",
+    "$$\n",
+    "Vale la pena notar que la variable independiente respecto a la que estamos\n",
+    "derivando es la que define a la función identidad, y que su derivada es 1."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Aritmética de duales"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Para $\\mathbb{D}_{x_0} u = (u_0, u^\\prime_0)$ y\n",
+    "$\\mathbb{D}_{x_0} w = (w_0, w^\\prime_0)$, y *definiendo* $\\epsilon^2=0$,\n",
+    "usando simple álgebra, tenemos que las operaciones aritméticas para los\n",
+    "números duales vienen dadas por:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "$$\n",
+    "\\begin{align*}\n",
+    "   \\pm \\mathbb{D}_{x_0} u & = \\big(\\pm u_0, \\pm u'_0 \\big), \\\\\n",
+    "\\mathbb{D}_{x_0} (u\\pm w) & = \\mathbb{D}_{x_0} u \\pm \\mathbb{D}_{x_0} w =\n",
+    "    \\big( u_0 \\pm w_0, \\, u'_0\\pm w'_0 \\big),\\\\\n",
+    "\\mathbb{D}_{x_0} (u \\cdot w) & = \\mathbb{D}_{x_0} u \\cdot \\mathbb{D}_{x_0} w =\n",
+    "    \\big( u_0 w_0,\\, u_0 w'_0 +  w_0 u'_0 \\big),\\\\\n",
+    "\\mathbb{D}_{x_0} \\frac{u}{w} & = \\frac{\\mathbb{D}_{x_0} u}{\\mathbb{D}_{x_0} w} =\n",
+    "    \\big( \\frac{u_0}{w_0},\\, \\frac{ u'_0 - (u_0/w_0)w'_0}{w_0}\\big),\\\\\n",
+    "{\\mathbb{D}_{x_0} u}^n & = \\mathbb{D}_{x_0}u \\cdot {\\mathbb{D}_{x_0} u}^n = \\big( u_0^n,\\, n u_0^{n-1} u'_0 \\big).\\\\\n",
+    "\\end{align*}\n",
+    "$$"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Claramente, en las expresiones anteriores la segunda componente corresponde\n",
+    "a la derivada de la operación aritmética involucrada.\n",
+    "Finalmente, vale la pena también notar que, en las operaciones\n",
+    "aritméticas *ambos* los duales están definidos en el mismo punto $x_0$."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "#### Un ejemplo de cálculo con duales"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "A fin de desarrollar un ejemplo que utiliza las operaciones que hemos\n",
+    "definido entre duales, evaluaremos la función\n",
+    "$f(x) = (3x^2-8x+5)/(7x^3-1)$ y su derivada en $x=2$. Para esto usaremos\n",
+    "el dual $u = 2 + \\epsilon$; vale la pena enfatizar\n",
+    "que este dual corresponde a la variable *independiente* $x$ evaluada en 2,\n",
+    "es decir, la función identidad evaluada en 2, $u = {\\mathbb{D}_{2} x}$,\n",
+    "que corresponde en efecto a la variable independiente\n",
+    "ya que su derivada (en cualquier punto) es 1."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "(Si todo lo que hemos hecho es consistente, la primer componente\n",
+    "del resultado deberá corresponder a evaluar\n",
+    "[$f(2)=1/55$](https://www.wolframalpha.com/input?i=evaluate+%283x%5E2-8x%2B5%29%2F%287x%5E3-1%29+at+x+%3D+2),\n",
+    "y la segunda componente corresponderá a la derivada\n",
+    "[$f^\\prime(2)=136/3025$](https://www.wolframalpha.com/input?i=derivative%28%283x%5E2-8x%2B5%29%2F%287x%5E3-1%29%2C+x%2C+2%29).)"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "$$\n",
+    "\\begin{align*}\n",
+    "f(2+\\epsilon) = & \\frac{3u^2-8u+5}{7u^3-1} =\n",
+    "            \\frac{3(2+\\epsilon)^2-8(2+\\epsilon)+5}{7(2+\\epsilon)^3-1} \\\\\n",
+    "        = & \\frac{3*2^2-8*2^1+5 +\\epsilon(2*3*2^1-8) + 3\\epsilon^2}{7*2^3-1 + \\epsilon(3*7*2^2) + 7*2*3\\epsilon^2 + 7\\epsilon^3} \\\\\n",
+    "        = & \\frac{1+4\\epsilon}{55+84\\epsilon} =\n",
+    "            \\frac{1}{55} + \\epsilon \\frac{4-\\frac{1}{55}(84)}{55}\n",
+    "            = \\frac{1}{55} + \\epsilon \\frac{4*55-84}{3025}\n",
+    "            = \\frac{1}{55} + \\epsilon \\frac{136}{3025}.\\\\\n",
+    "\\end{align*}\n",
+    "$$"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Los resultados claramente corresponden con la interpretación que queremos.\n",
+    "Es importante recalcar que si el dual es de la forma\n",
+    "$u = {\\mathbb{D}_{x_0} x}$, es decir, corresponde a la\n",
+    "variable independiente evaluada en $x_0$, la segunda componente\n",
+    "de $f(u)$ corresponde a la derivada $f^\\prime(x_0)$."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Funciones definidas sobre los duales"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "La regla de la cadena es fundamental para el cálculo de las derivadas,\n",
+    "y por lo mismo, se aplicará para definir funciones sobre duales.\n",
+    "Definiremos la aplicación de funciones en duales, buscando que la\n",
+    "interpretación del dual sea preservada: la primer componente del par\n",
+    "ordenado debe corresponder a la composición de las funciones, y la\n",
+    "segunda a su derivada."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Entonces, dado que\n",
+    "$$\n",
+    "\\frac{\\textrm{d}\\exp(f(x))}{\\textrm{d}x}(x_0) = \\exp(f(x_0)) f^\\prime(x_0),\n",
+    "$$\n",
+    "para ${\\mathbb{D}_{x_0} u}=u_0+\\epsilon u_0^\\prime$ podemos escribir\n",
+    "$$\n",
+    "\\exp({\\mathbb{D}_{x_0} u}) = \\exp(u) = \\exp(u_0+\\epsilon u_0^\\prime)\n",
+    "    = \\exp(u_0)+ \\epsilon \\exp(u_0) u_0^\\prime.\n",
+    "$$"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "De manera similar podemos obtener\n",
+    "$$\n",
+    "\\begin{align*}\n",
+    "\\exp({\\mathbb{D}_{x_0} u}) & = \\exp(u_0) + \\epsilon \\exp(u_0) u_0^\\prime,\\\\\n",
+    "\\log({\\mathbb{D}_{x_0} u}) & = \\log(u_0) + \\epsilon \\frac{u_0^\\prime}{u_0},\\\\\n",
+    "\\sin({\\mathbb{D}_{x_0} u}) & = \\sin(u_0) + \\epsilon \\cos(u_0) u_0^\\prime,\\\\\n",
+    "\\cos({\\mathbb{D}_{x_0} u}) & = \\cos(u_0) - \\epsilon \\sin(u_0) u_0^\\prime,\\\\\n",
+    "\\tan({\\mathbb{D}_{x_0} u}) & = \\tan(u_0) + \\epsilon \\sec^2(u_0) u_0^\\prime,\\\\\n",
+    "\\sinh({\\mathbb{D}_{x_0} u}) & = \\sinh(u_0) + \\epsilon \\cosh(u_0) u_0^\\prime,\\\\\n",
+    "\\dots\n",
+    "\\end{align*}\n",
+    "$$"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Al igual que antes, lo importante de estas expresiones es que si\n",
+    "$u = {\\mathbb{D}_{x_0} x}$ es la variable independiente evaluada\n",
+    "en $x_0$ (la derivada de $u$ es 1), entonces\n",
+    "la segunda componente de $f(u)$ corresponderá a $f^\\prime(x_0)$.\n",
+    "Las reglas anteriores garantizan que la composición de funciones se\n",
+    "puede usar con duales."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Epílogo"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Citando a [wikipedia](https://en.wikipedia.org/wiki/Automatic_differentiation):\n",
+    "\n",
+    "> Automatic differentiation (AD), also called algorithmic differentiation or computational differentiation [...], is a set of techniques to numerically evaluate the derivative of a function specified by a computer program."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Diferenciación automática **no es** diferenciación numérica. Está\n",
+    "basada en cálculos numéricos (evaluación de funciones en la computadora\n",
+    "con números de precisión finita), pero **no** usa ninguna de las\n",
+    "definiciones basadas en diferencias finitas. Tampoco es diferenciación\n",
+    "simbólica. La implementación que hemos descrito se basa en definir\n",
+    "los números duales, que son estructuras adecuadas que permiten obtener\n",
+    "los resultados que buscamos."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "---\n",
+    "\n",
+    "*This notebook was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*"
+   ],
+   "metadata": {}
+  }
+ ],
+ "nbformat_minor": 3,
+ "metadata": {
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.11.0-rc3"
+  },
+  "kernelspec": {
+   "name": "julia-1.11",
+   "display_name": "Julia 1.11.0-rc3",
+   "language": "julia"
+  }
+ },
+ "nbformat": 4
+}


### PR DESCRIPTION
Resulta que incluir docstrings en las funciones dentro de los evaluated blocks pueden bloquear generar el .ipynb desde el .jl para Literate.

Agregué unas comillas a 

```text
Evalua ```f``` en ```x_0``` ...
function foo(...)
```

para que pudiera hacer el port con Literate y cambie el archivo `04-DiffAutomatica.jl` por un `04-DiffAutomatica.ipynb`.